### PR TITLE
Hospitality director fixes

### DIFF
--- a/Content.Shared/Access/Components/IdCardConsoleComponent.cs
+++ b/Content.Shared/Access/Components/IdCardConsoleComponent.cs
@@ -92,6 +92,7 @@ public sealed partial class IdCardConsoleComponent : Component
         "Prosecutor", // Delta V - Add Prosecutor access
         "Clerk", // Delta V - Add Clerk access
         "Justicar", // Gardenstation - add justicar access
+        "HospitalityDirector", // Gardenstation - add justicar access
     };
 
     [Serializable, NetSerializable]

--- a/Resources/Locale/en-US/_Impstation/prototypes/access/accesses.ftl
+++ b/Resources/Locale/en-US/_Impstation/prototypes/access/accesses.ftl
@@ -1,0 +1,1 @@
+id-card-access-level-hospitality-director = Hospitality Director

--- a/Resources/Prototypes/Access/misc.yml
+++ b/Resources/Prototypes/Access/misc.yml
@@ -8,6 +8,7 @@
   - ChiefMedicalOfficer
   - HeadOfSecurity
   - ResearchDirector
+  - HospitalityDirector 
   - Command
   - Cryogenics
   - Security

--- a/Resources/Prototypes/Access/service.yml
+++ b/Resources/Prototypes/Access/service.yml
@@ -1,4 +1,8 @@
 - type: accessLevel
+  id: HospitalityDirector
+  name: id-card-access-level-hospitality-director
+
+- type: accessLevel
   id: Bar
   name: id-card-access-level-bar
 
@@ -34,6 +38,7 @@
   id: Service
   tags:
   - HeadOfPersonnel
+  - HospitalityDirector # Gardenstation - Add Hospitality Director from Impstation
   - Bar
   - Kitchen
   - Hydroponics

--- a/Resources/Prototypes/Loadouts/Jobs/Command/uncategorized.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/uncategorized.yml
@@ -25,7 +25,7 @@
   id: LoadoutCommandDisabler
   category: JobsCommandAUncategorized
   cost: 2
-  exclusive: true
+  exclusive: false
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutCommandSelfDefense
@@ -39,7 +39,7 @@
   id: LoadoutCommandStunBaton
   category: JobsCommandAUncategorized
   cost: 1
-  exclusive: true
+  exclusive: false
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutCommandSelfDefense

--- a/Resources/Prototypes/_Gardenstation/Entities/Clothing/Multiple/supertowel.yml
+++ b/Resources/Prototypes/_Gardenstation/Entities/Clothing/Multiple/supertowel.yml
@@ -1,4 +1,4 @@
-﻿- type: entity # im going insane - figure out why i cant add more slots later // its the next day (7-29) and i figured it out yay
+- type: entity # im going insane - figure out why i cant add more slots later // its the next day (7-29) and i figured it out yay
   abstract: true
   parent: [ UnsensoredClothingUniformBase, ClothingHeadBase, ClothingBeltBase, ClothingNeckBase, ClothingOuterBase, ClothingHandsBase, ClothingMaskGas ]
   id: SuperTowel
@@ -149,7 +149,7 @@
   - type: Clothing
     sprite: _Gardenstation/Clothing/Multiple/hd_towel.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 2.5
+    walkModifier: 2.0
     sprintModifier: 0.50
   - type: HeldSpeedModifier
   - type: Fiber

--- a/Resources/Prototypes/_Impstation/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -19,3 +19,25 @@
       sprite: _Impstation/Clothing/Uniforms/Jumpskirt/hd_turtle.rsi
     - type: Clothing
       sprite: _Impstation/Clothing/Uniforms/Jumpskirt/hd_turtle.rsi
+
+- type: entity
+  parent: [ClothingUniformBase, BaseCommandContraband]
+  id: ClothingUniformJumpskirtHospitalityDirectorBartender
+  name: lead bartending uniform
+  description: This uniform lets the people know you can make a really mean raktaccino.
+  components:
+  - type: Sprite
+    sprite: _Impstation/Clothing/Uniforms/Jumpskirt/hd_bartender.rsi
+  - type: Clothing
+    sprite: _Impstation/Clothing/Uniforms/Jumpskirt/hd_bartender.rsi
+
+- type: entity
+  parent: [ClothingUniformBase, BaseCommandContraband]
+  id: ClothingUniformJumpskirtHospitalityDirectorJanitor
+  name: lead custodial jumpskirt
+  description: This uniform shows that if anyone should get the janitor trolley, it's you.
+  components:
+  - type: Sprite
+    sprite: _Impstation/Clothing/Uniforms/Jumpskirt/hd_janitor.rsi
+  - type: Clothing
+    sprite: _Impstation/Clothing/Uniforms/Jumpskirt/hd_janitor.rsi

--- a/Resources/Prototypes/_Impstation/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -19,3 +19,36 @@
       sprite: _Impstation/Clothing/Uniforms/Jumpsuit/hd_turtle.rsi
     - type: Clothing
       sprite: _Impstation/Clothing/Uniforms/Jumpsuit/hd_turtle.rsi
+
+- type: entity
+  parent: [ClothingUniformBase, ClothingUniformFoldableBase, BaseCommandContraband]
+  id: ClothingUniformJumpsuitHospitalityDirectorBartender
+  name: lead bartending uniform
+  description: This uniform lets the people know you can make a really mean raktaccino.
+  components:
+  - type: Sprite
+    sprite: _Impstation/Clothing/Uniforms/Jumpsuit/hd_bartender.rsi
+  - type: Clothing
+    sprite: _Impstation/Clothing/Uniforms/Jumpsuit/hd_bartender.rsi
+
+- type: entity
+  parent: [ClothingUniformBase, BaseCommandContraband]
+  id: ClothingUniformJumpsuitHospitalityDirectorBotany
+  name: lead botanical overalls
+  description: Nice sturdy overalls, great for working in the dirt and cultivating tritium-producing cocoa.
+  components:
+  - type: Sprite
+    sprite: _Impstation/Clothing/Uniforms/Jumpsuit/hd_botany.rsi
+  - type: Clothing
+    sprite: _Impstation/Clothing/Uniforms/Jumpsuit/hd_botany.rsi
+
+- type: entity
+  parent: [ClothingUniformBase, ClothingUniformFoldableBase, BaseCommandContraband]
+  id: ClothingUniformJumpsuitHospitalityDirectorJanitor
+  name: lead custodial jumpsuit
+  description: This uniform shows that if anyone should get the janitor trolley, it's you.
+  components:
+  - type: Sprite
+    sprite: _Impstation/Clothing/Uniforms/Jumpsuit/hd_janitor.rsi
+  - type: Clothing
+    sprite: _Impstation/Clothing/Uniforms/Jumpsuit/hd_janitor.rsi

--- a/Resources/Prototypes/_Impstation/Roles/Jobs/Civilian/hospitalitydirector.yml
+++ b/Resources/Prototypes/_Impstation/Roles/Jobs/Civilian/hospitalitydirector.yml
@@ -35,6 +35,7 @@
   canBeAntag: false
   access:
   - Command
+  - HospitalityDirector 
   - Service
   - Maintenance
   - Janitor
@@ -45,6 +46,9 @@
   - Theatre
   - Clown
   - Mime
+  - Reporter
+  - Zookeeper
+  - Library 
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable


-->
The Hospitality Director was still somewhat half-baked, with some features not making it into the first playtest and some unintended behavior rearing its head. The towel should no longer be overridden by certain loadout items, and provides a more reasonable (but still appreciable) move speed buff. The Hospitality Director now has their own access level for when their office is mapped in, and they have been provided additional civilian accesses as well. Their jumpsuit/skirt varients have been given prototypes. 

The HD is still in dire need of a mapped office that their alternate uniforms and towel can spawn in, but this should have us ready to begin that project.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Add prototypes for alternate uniforms
- [x] Add tempfix for towel spawn
- [x] Add HD access level 
- [ ] Map HD offices


---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added Hospitality Director access level
- tweak: Gave the HD Reporter, Librarian, and Zookeeper access
- tweak: Lowered the SuperTowel walkspeed buff from 2.5x to 2.0x
- fix: Equipping certain command sidearms will no longer cause the HD to spawn without their towel
