### PR TITLE
vote fail fix

### DIFF
--- a/Content.Shared/CCVar/CCVars.AutoVote.cs
+++ b/Content.Shared/CCVar/CCVars.AutoVote.cs
@@ -12,5 +12,5 @@ public sealed partial class CCVars
     /// Automatically starts a gamemode vote when returning to the lobby.
     /// Requires auto voting to be enabled.
     public static readonly CVarDef<bool> PresetAutoVoteEnabled =
-        CVarDef.Create("vote.preset_autovote_enabled", true, CVar.SERVERONLY);
+        CVarDef.Create("vote.preset_autovote_enabled", false, CVar.SERVERONLY);
 }


### PR DESCRIPTION
### **TL;DR**
**2 am solo salv shifts are back on the menu. default gamemode is secret (most antags are a possibility)**
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

disabled preround gamemode voting, the server would delay roundstart forever if there werent enough players for the gamemode that won. This just makes secret the default while still allowing players and admins to call a gamemode vote through the menu, or change it via commands preround.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [ ] add custom game presets
- [ ] re-enable voting once custom presets are implemented
- [x] fix infinite delays

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: implement secret as default gamemode
- tweak: disabled auto gamemode vote
