### PR TITLE
edit stencils and displacemnt refs to remove pervert vision from nvg

### DIFF
--- a/Resources/Prototypes/Shaders/Stencils.yml
+++ b/Resources/Prototypes/Shaders/Stencils.yml
@@ -20,6 +20,6 @@
   id: StencilDraw
   kind: canvas
   stencil:
-    ref: 1
+    ref: 2
     op: Keep
     func: NotEqual

--- a/Resources/Prototypes/Shaders/displacement.yml
+++ b/Resources/Prototypes/Shaders/displacement.yml
@@ -3,7 +3,7 @@
   kind: source
   path: "/Textures/Shaders/displacement.swsl"
   stencil:
-    ref: 1
+    ref: 2
     op: Keep
     func: NotEqual
   params:

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -862,7 +862,7 @@
 - type: trait
   id: ThermographicVision
   category: Physical
-  points: -4
+  points: -2 # idk man it kinda just sucks rn. if we reinstate the passive nightvision regalis had then mb we bump it up but otherwise its just a shitty flashlight/iseeyou button. plus you can hear ppl thru walls so why does it matter anyways. lets just remove the trait and also footsteps and localchat
   requirements:
     - !type:CharacterJobRequirement
       inverted: true


### PR DESCRIPTION

<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

no more pervert vision. 

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [ ] make more weird cybernetics
- [x] fix that thing i hate

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: stencil and displacement layers to make nvg not creepy
- tweak: made thermos cheaper since they suck rn