### PR TITLE
Rotting rework

### DIFF
--- a/Content.Server/Body/Components/MetabolizerComponent.cs
+++ b/Content.Server/Body/Components/MetabolizerComponent.cs
@@ -1,3 +1,23 @@
+// SPDX-FileCopyrightText: 2021 Ygg01 <y.laughing.man.y@gmail.com>
+// SPDX-FileCopyrightText: 2022 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
+// SPDX-FileCopyrightText: 2022 Vera Aguilera Puerto <6766154+Zumorica@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2022 mirrorcult <lunarautomaton6@gmail.com>
+// SPDX-FileCopyrightText: 2022 wrexbe <81056464+wrexbe@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2023 TemporalOroboros <temporaloroboros@gmail.com>
+// SPDX-FileCopyrightText: 2024 Angelo Fallaria <ba.fallaria@gmail.com>
+// SPDX-FileCopyrightText: 2024 FoxxoTrystan <trystan.garnierhein@gmail.com>
+// SPDX-FileCopyrightText: 2024 VMSolidus <evilexecutive@gmail.com>
+// SPDX-FileCopyrightText: 2024 fox <daytimer253@gmail.com>
+// SPDX-FileCopyrightText: 2024 neuPanda <chriseparton@gmail.com>
+// SPDX-FileCopyrightText: 2025 Raikyr0 <Kurohana@hotmail.com.au>
+// SPDX-FileCopyrightText: 2025 portfiend <109661617+portfiend@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 sleepyyapril <flyingkarii@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
+using Content.Server._DEN.Traits;
 using Content.Server.Body.Systems;
 using Content.Server.Traits.Assorted;
 using Content.Shared.Body.Prototypes;
@@ -46,7 +66,11 @@ namespace Content.Server.Body.Components
         ///     List of metabolizer types that this organ is. ex. Human, Slime, Felinid, w/e.
         /// </summary>
         [DataField]
-        [Access(typeof(MetabolizerSystem), typeof(LiquorLifelineSystem), typeof(VampirismSystem), Other = AccessPermissions.ReadExecute)] // FIXME Friends
+        [Access(typeof(MetabolizerSystem),
+            typeof(LiquorLifelineSystem),
+            typeof(VampirismSystem),
+            typeof(TraitAddMetabolizer),
+            Other = AccessPermissions.ReadExecute)] // FIXME Friends
         public HashSet<ProtoId<MetabolizerTypePrototype>>? MetabolizerTypes = null;
 
         /// <summary>

--- a/Content.Server/Cocoon/CocoonerSystem.cs
+++ b/Content.Server/Cocoon/CocoonerSystem.cs
@@ -1,3 +1,14 @@
+// SPDX-FileCopyrightText: 2024 Aiden <aiden@djkraz.com>
+// SPDX-FileCopyrightText: 2024 FoxxoTrystan <45297731+FoxxoTrystan@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2024 FoxxoTrystan <trystan.garnierhein@gmail.com>
+// SPDX-FileCopyrightText: 2024 VMSolidus <evilexecutive@gmail.com>
+// SPDX-FileCopyrightText: 2024 sleepyyapril <flyingkarii@gmail.com>
+// SPDX-FileCopyrightText: 2025 Sapphire <98045970+sapphirescript@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 portfiend <109661617+portfiend@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
 using Content.Shared.Cocoon;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Verbs;
@@ -19,11 +30,13 @@ using Robust.Shared.Random;
 using Content.Shared.Nutrition.Components;
 using Content.Shared.Storage;
 using Robust.Shared.Utility;
+using Content.Shared._DEN.Kitchen;
 
 namespace Content.Server.Cocoon
 {
     public sealed class CocooningSystem : EntitySystem
     {
+        [Dependency] private readonly SharedButcherySystem _butcherySystem = default!;
         [Dependency] private readonly PopupSystem _popupSystem = default!;
         [Dependency] private readonly DoAfterSystem _doAfter = default!;
         [Dependency] private readonly ItemSlotsSystem _itemSlots = default!;
@@ -184,13 +197,7 @@ namespace Content.Server.Cocoon
                 return;
 
             if (TryComp<ButcherableComponent>(args.Args.Target.Value, out var butcher))
-            {
-                var spawnEntities = EntitySpawnCollection.GetSpawns(butcher.SpawnedEntities, _robustRandom);
-                var coords = Transform(args.Args.Target.Value).MapPosition;
-                EntityUid popupEnt = default!;
-                foreach (var proto in spawnEntities)
-                    popupEnt = Spawn(proto, coords.Offset(_robustRandom.NextVector2(0.25f)));
-            }
+                _butcherySystem.SpawnButcherableProducts(args.Args.Target.Value, butcher);
 
             _destructibleSystem.DestroyEntity(args.Args.Target.Value);
 

--- a/Content.Server/Kitchen/EntitySystems/KitchenSpikeSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/KitchenSpikeSystem.cs
@@ -42,6 +42,7 @@ using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Kitchen;
 using Content.Shared.Kitchen.Components;
+using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Nutrition.Components;
@@ -200,7 +201,6 @@ namespace Content.Server.Kitchen.EntitySystems
 
             if (TryComp<PerishableComponent>(spiked, out var perishable))
             {
-                Log.Info("Found perishable entity!");
                 var ent = new Entity<PerishableComponent>(spiked.Value, perishable);
                 var examineText = _rotting.GetPerishableExamineText(ent);
                 if (examineText != string.Empty)
@@ -270,6 +270,9 @@ namespace Content.Server.Kitchen.EntitySystems
             CopyComponent<PerishableComponent>(victimId, ent);
             CopyComponent<RottingComponent>(victimId, ent);
             CopyComponent<TemperatureComponent>(victimId, ent);
+
+            TryComp<MobStateComponent>(ent, out var mobState); //Garden - mobs weren't rotting on meatspikes bc the virtual entity was not
+            _mobStateSystem.ChangeMobState(ent, MobState.Dead, mobState); //being read as dead, this seems to fix it
             return ent;
         }
 

--- a/Content.Server/Kitchen/EntitySystems/KitchenSpikeSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/KitchenSpikeSystem.cs
@@ -1,12 +1,42 @@
+// SPDX-FileCopyrightText: 2021 FoLoKe <36813380+FoLoKe@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2022 Jezithyr <Jezithyr.@gmail.com>
+// SPDX-FileCopyrightText: 2022 Jezithyr <Jezithyr@gmail.com>
+// SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
+// SPDX-FileCopyrightText: 2022 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2022 metalgearsloth <comedian_vs_clown@hotmail.com>
+// SPDX-FileCopyrightText: 2022 mirrorcult <lunarautomaton6@gmail.com>
+// SPDX-FileCopyrightText: 2022 wrexbe <81056464+wrexbe@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2023 DrSmugleaf <drsmugleaf@gmail.com>
+// SPDX-FileCopyrightText: 2023 Jezithyr <jezithyr@gmail.com>
+// SPDX-FileCopyrightText: 2023 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2023 Pieter-Jan Briers <pieterjan.briers@gmail.com>
+// SPDX-FileCopyrightText: 2023 Slava0135 <40753025+Slava0135@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2023 Visne <39844191+Visne@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2023 keronshb <54602815+keronshb@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2023 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2024 Scribbles0 <91828755+Scribbles0@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2024 nikthechampiongr <32041239+nikthechampiongr@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 M3739 <47579354+M3739@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 portfiend <109661617+portfiend@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later AND MIT   
+
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Content.Server.Administration.Logs;
 using Content.Server.Body.Systems;
 using Content.Server.Kitchen.Components;
 using Content.Server.Popups;
+using Content.Server.Temperature.Components;
+using Content.Shared.Atmos.Rotting;
 using Content.Shared.Chat;
 using Content.Shared.Damage;
 using Content.Shared.Database;
 using Content.Shared.DoAfter;
 using Content.Shared.DragDrop;
+using Content.Shared.Examine;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
@@ -19,14 +49,18 @@ using Content.Shared.Popups;
 using Content.Shared.Storage;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Containers;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
+using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Utility;
 using static Content.Shared.Kitchen.Components.KitchenSpikeComponent;
 
 namespace Content.Server.Kitchen.EntitySystems
 {
     public sealed class KitchenSpikeSystem : SharedKitchenSpikeSystem
     {
+        [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
         [Dependency] private readonly PopupSystem _popupSystem = default!;
         [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
         [Dependency] private readonly IAdminLogManager _logger = default!;
@@ -38,11 +72,15 @@ namespace Content.Server.Kitchen.EntitySystems
         [Dependency] private readonly SharedAudioSystem _audio = default!;
         [Dependency] private readonly MetaDataSystem _metaData = default!;
         [Dependency] private readonly SharedSuicideSystem _suicide = default!;
+        [Dependency] private readonly ISerializationManager _serMan = default!;
+        [Dependency] private readonly SharedRottingSystem _rotting = default!;
 
         public override void Initialize()
         {
             base.Initialize();
 
+            SubscribeLocalEvent<KitchenSpikeComponent, ComponentInit>(OnInit);
+            SubscribeLocalEvent<KitchenSpikeComponent, ComponentShutdown>(OnRemove);
             SubscribeLocalEvent<KitchenSpikeComponent, InteractUsingEvent>(OnInteractUsing);
             SubscribeLocalEvent<KitchenSpikeComponent, InteractHandEvent>(OnInteractHand);
             SubscribeLocalEvent<KitchenSpikeComponent, DragDropTargetEvent>(OnDragDrop);
@@ -51,8 +89,20 @@ namespace Content.Server.Kitchen.EntitySystems
             SubscribeLocalEvent<KitchenSpikeComponent, SpikeDoAfterEvent>(OnDoAfter);
 
             SubscribeLocalEvent<KitchenSpikeComponent, SuicideByEnvironmentEvent>(OnSuicideByEnvironment);
+            SubscribeLocalEvent<KitchenSpikeComponent, ExaminedEvent>(OnExamined);
 
             SubscribeLocalEvent<ButcherableComponent, CanDropDraggedEvent>(OnButcherableCanDrop);
+        }
+        private void OnInit(EntityUid uid, KitchenSpikeComponent spike, ComponentInit args)
+        {
+            var cont = _containerSystem.EnsureContainer<Container>(uid, spike.ContainerName);
+            spike.SpikeContainer = cont;
+        }
+
+        private void OnRemove(EntityUid uid, KitchenSpikeComponent spike, ComponentShutdown args)
+        {
+            if (spike.SpikeContainer != null)
+                _containerSystem.CleanContainer(spike.SpikeContainer);
         }
 
         private void OnButcherableCanDrop(Entity<ButcherableComponent> entity, ref CanDropDraggedEvent args)
@@ -137,6 +187,36 @@ namespace Content.Server.Kitchen.EntitySystems
                 args.Handled = true;
         }
 
+        private void OnExamined(Entity<KitchenSpikeComponent> spike, ref ExaminedEvent args)
+        {
+            var comp = spike.Comp;
+            var hasSpiked = TryGetSpikedEntity(spike, comp, out var spiked);
+
+            if (!hasSpiked)
+            {
+                Log.Info("Could not find spiked entity!");
+                return;
+            }
+
+            if (TryComp<PerishableComponent>(spiked, out var perishable))
+            {
+                Log.Info("Found perishable entity!");
+                var ent = new Entity<PerishableComponent>(spiked.Value, perishable);
+                var examineText = _rotting.GetPerishableExamineText(ent);
+                if (examineText != string.Empty)
+                    args.PushMarkup(examineText);
+            }
+
+            if (TryComp<RottingComponent>(spiked, out var rotting))
+            {
+                Log.Info("Found rotting entity!");
+                var ent = new Entity<RottingComponent>(spiked.Value, rotting);
+                var examineText = _rotting.GetRottingExamineText(ent);
+                if (examineText != string.Empty)
+                    args.PushMarkup(examineText);
+            }
+        }
+
         private void Spike(EntityUid uid, EntityUid userUid, EntityUid victimUid,
             KitchenSpikeComponent? component = null, ButcherableComponent? butcherable = null)
         {
@@ -146,12 +226,14 @@ namespace Content.Server.Kitchen.EntitySystems
             _logger.Add(LogType.Gib, LogImpact.Extreme, $"{ToPrettyString(userUid):user} kitchen spiked {ToPrettyString(victimUid):target}");
 
             // TODO VERY SUS
+            var virtualEnt = CreateVirtualSpikedEntity(uid, victimUid);
+            _containerSystem.Insert(virtualEnt, component.SpikeContainer);
             component.PrototypesToSpawn = EntitySpawnCollection.GetSpawns(butcherable.SpawnedEntities, _random);
 
             // This feels not okay, but entity is getting deleted on "Spike", for now...
-            component.MeatSource1p = Loc.GetString("comp-kitchen-spike-remove-meat", ("victim", victimUid));
-            component.MeatSource0 = Loc.GetString("comp-kitchen-spike-remove-meat-last", ("victim", victimUid));
-            component.Victim = Name(victimUid);
+            //component.MeatSource1p = Loc.GetString("comp-kitchen-spike-remove-meat", ("victim", victimUid));
+            //component.MeatSource0 = Loc.GetString("comp-kitchen-spike-remove-meat-last", ("victim", victimUid));
+            //component.Victim = Name(victimUid);
 
             UpdateAppearance(uid, null, component);
 
@@ -161,21 +243,57 @@ namespace Content.Server.Kitchen.EntitySystems
             // THE WHAT?
             // TODO: Need to be able to leave them on the spike to do DoT, see ss13.
             var gibs = _bodySystem.GibBody(victimUid);
-            foreach (var gib in gibs) {
+            foreach (var gib in gibs)
                 QueueDel(gib);
-            }
 
             _audio.PlayEntity(component.SpikeSound, Filter.Pvs(uid), uid, true);
+        }
+
+        /// <summary>
+        /// Creates a "basic" representation of a butchered entity using only components
+        /// that are relevant to meat spiking. TODO storing the real entity on the spike and making
+        /// sure it doesn't suck when we do
+        /// </summary>
+        /// <param name="spikeId">The ID of the spike entity.</param>
+        /// <param name="victimId">The ID of the entity being spiked.</param>
+        /// <returns>The ID of the new "virtual" enttity.</returns>
+        private EntityUid CreateVirtualSpikedEntity(EntityUid spikeId, EntityUid victimId)
+        {
+            var ent = Spawn(null, Transform(spikeId).Coordinates);
+
+            var meta = EnsureComp<MetaDataComponent>(ent);
+            if (TryComp(victimId, out MetaDataComponent? victimMeta))
+                _metaData.SetEntityName(ent, victimMeta.EntityName, meta);
+
+            CopyComponent<MobStateComponent>(victimId, ent);
+            CopyComponent<ButcherableComponent>(victimId, ent);
+            CopyComponent<PerishableComponent>(victimId, ent);
+            CopyComponent<RottingComponent>(victimId, ent);
+            CopyComponent<TemperatureComponent>(victimId, ent);
+            return ent;
+        }
+
+        // TODO: move this somewhere that isn't KitchenSpikeSystem
+        private void CopyComponent<T>(EntityUid src, EntityUid target) where T : Component, new()
+        {
+            if (!TryComp<T>(src, out var srcComp))
+                return;
+
+            var targetComp = EnsureComp<T>(target);
+            _serMan.CopyTo(srcComp, ref targetComp, notNullableOverride: true);
         }
 
         private bool TryGetPiece(EntityUid uid, EntityUid user, EntityUid used,
             KitchenSpikeComponent? component = null, SharpComponent? sharp = null)
         {
-            if (!Resolve(uid, ref component) || component.PrototypesToSpawn == null || component.PrototypesToSpawn.Count == 0)
+            if (!Resolve(uid, ref component)
+                || component.PrototypesToSpawn == null
+                || component.PrototypesToSpawn.Count == 0
+                || !TryGetSpikedEntity(uid, component, out var spiked))
                 return false;
 
             // Is using knife
-            if (!Resolve(used, ref sharp, false) )
+            if (!Resolve(used, ref sharp, false))
             {
                 return false;
             }
@@ -184,25 +302,66 @@ namespace Content.Server.Kitchen.EntitySystems
 
             var ent = Spawn(item, Transform(uid).Coordinates);
             _metaData.SetEntityName(ent,
-                Loc.GetString("comp-kitchen-spike-meat-name", ("name", Name(ent)), ("victim", component.Victim)));
+                Loc.GetString("comp-kitchen-spike-meat-name",
+                    ("name", Name(ent)),
+                    ("victim", Name(spiked.Value))));
+
+            _rotting.TransferFreshness(spiked.Value, ent, true);
+            _rotting.TransferRotStage(spiked.Value, ent, true);
 
             if (component.PrototypesToSpawn.Count != 0)
-                _popupSystem.PopupEntity(component.MeatSource1p, uid, user, PopupType.MediumCaution);
+                _popupSystem.PopupEntity(Loc.GetString("comp-kitchen-spike-remove-meat",
+                    ("victim", spiked)),
+                    uid,
+                    user,
+                    PopupType.MediumCaution);
             else
             {
+                _popupSystem.PopupEntity(Loc.GetString("comp-kitchen-spike-remove-meat-last",
+                    ("victim", spiked)),
+                    uid,
+                    user,
+                    PopupType.MediumCaution);
+
+                RemoveSpikedEntity(uid, component);
                 UpdateAppearance(uid, null, component);
-                _popupSystem.PopupEntity(component.MeatSource0, uid, user, PopupType.MediumCaution);
             }
 
             return true;
         }
+
+        private bool TryGetSpikedEntity(EntityUid uid,
+            KitchenSpikeComponent? component,
+            [NotNullWhen(true)] out EntityUid? spikedEntity)
+        {
+            spikedEntity = null;
+            if (!Resolve(uid, ref component)
+                || component.SpikeContainer.Count == 0)
+                return false;
+
+            spikedEntity = component.SpikeContainer.ContainedEntities.First();
+            return spikedEntity != null;
+        }
+
+        public void RemoveSpikedEntity(EntityUid uid, KitchenSpikeComponent comp)
+        {
+            if (TryGetSpikedEntity(uid, comp, out var spiked))
+            {
+                QueueDel(spiked);
+                _containerSystem.CleanContainer(comp.SpikeContainer);
+            }
+        }
+
 
         private void UpdateAppearance(EntityUid uid, AppearanceComponent? appearance = null, KitchenSpikeComponent? component = null)
         {
             if (!Resolve(uid, ref component, ref appearance, false))
                 return;
 
-            _appearance.SetData(uid, KitchenSpikeVisuals.Status, component.PrototypesToSpawn?.Count > 0 ? KitchenSpikeStatus.Bloody : KitchenSpikeStatus.Empty, appearance);
+            _appearance.SetData(uid,
+                KitchenSpikeVisuals.Status,
+                component.SpikeContainer.Count > 0 ? KitchenSpikeStatus.Bloody : KitchenSpikeStatus.Empty,
+                appearance);
         }
 
         private bool Spikeable(EntityUid uid, EntityUid userUid, EntityUid victimUid,
@@ -211,7 +370,8 @@ namespace Content.Server.Kitchen.EntitySystems
             if (!Resolve(uid, ref component))
                 return false;
 
-            if (component.PrototypesToSpawn?.Count > 0)
+            if (component.PrototypesToSpawn?.Count > 0
+                || component.SpikeContainer?.ContainedEntities.Count > 0)
             {
                 _popupSystem.PopupEntity(Loc.GetString("comp-kitchen-spike-deny-collect", ("this", uid)), uid, userUid);
                 return false;

--- a/Content.Server/Kitchen/EntitySystems/SharpSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/SharpSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Server.Body.Systems;
+using Content.Server.Body.Systems;
 using Content.Server.Kitchen.Components;
 using Content.Server.Nutrition.EntitySystems;
 using Content.Shared.Body.Components;
@@ -18,19 +18,20 @@ using Robust.Server.Containers;
 using Robust.Server.GameObjects;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
+using Content.Server.Atmos.Rotting;
+using Content.Shared._DEN.Kitchen;
 
 namespace Content.Server.Kitchen.EntitySystems;
 
 public sealed class SharpSystem : EntitySystem
 {
     [Dependency] private readonly BodySystem _bodySystem = default!;
+    [Dependency] private readonly SharedButcherySystem _butcherySystem = default!;
     [Dependency] private readonly SharedDestructibleSystem _destructibleSystem = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
     [Dependency] private readonly ContainerSystem _containerSystem = default!;
     [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
-    [Dependency] private readonly TransformSystem _transform = default!;
-    [Dependency] private readonly IRobustRandom _robustRandom = default!;
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
 
     public override void Initialize()
@@ -102,14 +103,7 @@ public sealed class SharpSystem : EntitySystem
             return;
         }
 
-        var spawnEntities = EntitySpawnCollection.GetSpawns(butcher.SpawnedEntities, _robustRandom);
-        var coords = _transform.GetMapCoordinates(args.Args.Target.Value);
-        EntityUid popupEnt = default!;
-        foreach (var proto in spawnEntities)
-        {
-            // distribute the spawned items randomly in a small radius around the origin
-            popupEnt = Spawn(proto, coords.Offset(_robustRandom.NextVector2(0.25f)));
-        }
+        var popupEnt = _butcherySystem.SpawnButcherableProducts(args.Args.Target.Value, butcher);
 
         var hasBody = TryComp<BodyComponent>(args.Args.Target.Value, out var body);
 
@@ -118,8 +112,11 @@ public sealed class SharpSystem : EntitySystem
         if (hasBody)
             popupType = PopupType.LargeCaution;
 
-        _popupSystem.PopupEntity(Loc.GetString("butcherable-knife-butchered-success", ("target", args.Args.Target.Value), ("knife", uid)),
-            popupEnt, args.Args.User, popupType);
+        if (popupEnt != null)
+            _popupSystem.PopupEntity(Loc.GetString("butcherable-knife-butchered-success",
+                ("target", args.Args.Target.Value),
+                ("knife", uid)),
+                popupEnt.Value, args.Args.User, popupType);
 
         if (hasBody)
             _bodySystem.GibBody(args.Args.Target.Value, body: body);

--- a/Content.Server/_DEN/Chemistry/ReplaceSolutionSystem.cs
+++ b/Content.Server/_DEN/Chemistry/ReplaceSolutionSystem.cs
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: 2025 portfiend <109661617+portfiend@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
+using Content.Shared._DEN.Chemistry;
+using Content.Shared.Atmos.Rotting;
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.Components.SolutionManager;
+using Content.Shared.Chemistry.EntitySystems;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
+
+namespace Content.Server._DEN.Chemistry.EntitySystems;
+
+public sealed class ReplaceSolutionSystem : SharedReplaceSolutionSystem
+{
+    [Dependency] private readonly IPrototypeManager _protoMan = default!;
+    [Dependency] private readonly SharedSolutionContainerSystem _solutionContainer = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        UpdateRottingEntities();
+    }
+
+    private void UpdateRottingEntities()
+    {
+        var query = EntityQueryEnumerator<ReplaceSolutionWhenRottenComponent,
+            RottingComponent,
+            SolutionContainerManagerComponent>();
+
+        while (query.MoveNext(out var uid, out var replaceSolution, out var _, out var manager))
+        {
+            UpdateEntityOnInterval(uid, replaceSolution, manager);
+        }
+    }
+
+    private void UpdateEntityOnInterval(EntityUid uid,
+        BaseReplaceSolutionIntervalComponent comp,
+        SolutionContainerManagerComponent manager)
+    {
+        if (_timing.CurTime < comp.NextReplaceTime)
+            return;
+
+        comp.NextReplaceTime = _timing.CurTime + comp.Duration;
+        UpdateEntity(uid, comp, manager);
+    }
+
+    /// <summary>
+    /// Performs replacements on an entity with the components needed to do so.
+    /// </summary>
+    /// <param name="uid">The ID of the entity to perform replacements on.</param>
+    /// <param name="comp">The BaseReplaceSolution component to use.</param>
+    /// <param name="manager">The SolutionContainerManager component on the entity.</param>
+    private void UpdateEntity(EntityUid uid,
+        BaseReplaceSolutionComponent comp,
+        SolutionContainerManagerComponent manager)
+    {
+        var success = _solutionContainer.ResolveSolution((uid, manager),
+            comp.SolutionName,
+            ref comp.SolutionRef,
+            out var solution);
+
+        if (!success || solution == null || comp.SolutionRef == null)
+            return;
+
+        var replacedSolution = ReplaceReagents(solution, comp);
+        _solutionContainer.RemoveAllSolution(comp.SolutionRef.Value);
+        _solutionContainer.AddSolution(comp.SolutionRef.Value, replacedSolution);
+    }
+
+    /// <summary>
+    /// Performs a replacement of a solution's reagents using the properties of a BaseReplaceSolutionComponent.
+    /// For example, the compoment may have a replacement rule that says to reduce the solution volume by 1u,
+    /// and then add 1u of Water to the solution.
+    /// </summary>
+    /// <param name="solution">The solution to perform replacements on</param>
+    /// <param name="replaceSolution">The solution replacement component.</param>
+    /// <returns>A new solution after replacements have been performed.</returns>
+    public Solution ReplaceReagents(Solution solution, BaseReplaceSolutionComponent replaceSolution)
+    {
+        var replacementTargetIds = replaceSolution.ReplacementReagentIds();
+        var replacedProducts = solution.Clone();
+        var solutionToReplace = replacedProducts.SplitSolutionWithout(replacedProducts.Volume, replacementTargetIds);
+
+        foreach (var replacement in replaceSolution.Replacements)
+        {
+            var replacementSolution = PerformReplacement(solutionToReplace, replacement);
+            replacedProducts.AddSolution(replacementSolution, _protoMan);
+        }
+
+        var finalResultSolution = solutionToReplace;
+        finalResultSolution.AddSolution(replacedProducts, _protoMan);
+        return finalResultSolution;
+    }
+
+    /// <summary>
+    /// Given a solution, reduce its volume and then create a solution of "replacement" reagents, scaling with
+    /// how much the solution was actually reduced by. Does not perform filtering on the input solution
+    /// for "byproducts", so if you fail to filter those out first, behavior may be unpredictable.
+    ///
+    /// This also modifies the input solution in place.
+    /// </summary>
+    /// <param name="solution">The solution to perform the placement on.</param>
+    /// <param name="replacement">The SolutionReplacement rule defining how to replace reagents.</param>
+    /// <param name="replacedOutput">The solution of "replacement" reagents generated.</param>
+    public Solution PerformReplacement(Solution solution, SolutionReplacement replacement)
+    {
+        if (solution.Volume <= 0 || replacement.ReplacementSolution.Volume <= 0)
+            return new Solution();
+
+        Solution? ignoredSolution = null;
+        if (replacement.Whitelist != null)
+            ignoredSolution = solution.SplitSolutionWithout(solution.Volume, replacement.Whitelist);
+
+        var originalVolume = solution.Volume;
+        solution.RemoveSolution(replacement.Amount);
+
+        // Important to make sure this scales with how much is actually replaced.
+        // For example, if it replaces 2u of Nutriment with 3u of Gastrotoxin,
+        // but there was only 1u left of Nutriment in the original solution,
+        // then it should only generate 1.5u of Gastrotoxin.
+        var replacedAmount = originalVolume - solution.Volume;
+        var replacementRatio = replacedAmount.Float() / replacement.Amount.Float();
+        var replacementSolution = replacement.ReplacementSolution.Clone();
+        replacementSolution.ScaleSolution(replacementRatio);
+
+        // If there's a whitelist, make sure we readd our non-whitelisted solution back.
+        if (ignoredSolution != null && ignoredSolution.Volume > 0)
+            solution.AddSolution(ignoredSolution, _protoMan);
+
+        return replacementSolution;
+    }
+}

--- a/Content.Server/_DEN/Traits/TraitSystem.Functions.cs
+++ b/Content.Server/_DEN/Traits/TraitSystem.Functions.cs
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2025 portfiend <109661617+portfiend@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
+using System.Linq;
+using Content.Server.Administration.Logs;
+using Content.Server.Body.Components;
+using Content.Shared.Body.Components;
+using Content.Shared.Body.Prototypes;
+using Content.Shared.Body.Systems;
+using Content.Shared.Database;
+using Content.Shared.Traits;
+using Content.Shared.Whitelist;
+using JetBrains.Annotations;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.Manager;
+
+namespace Content.Server._DEN.Traits;
+
+/// <summary>
+/// A trait function that will add metabolizers to the entity's organs.
+/// </summary>
+[UsedImplicitly]
+public sealed partial class TraitAddMetabolizer : TraitFunction
+{
+    /// <summary>
+    /// What metabolizers to add to the entity's organs.
+    /// </summary>
+    [DataField(required: true)]
+    public HashSet<ProtoId<MetabolizerTypePrototype>> Metabolizers = new();
+
+    /// <summary>
+    /// Conditions for the organs for them to receive the metabolizer.
+    /// You can use this to only apply the metabolizer to the stomach, for instance.
+    /// </summary>
+    [DataField("organWhitelist")]
+    public EntityWhitelist? Whitelist = null;
+
+    /// <summary>
+    /// Whether this trait should replace all metabolizers instead of simply adding them.
+    /// </summary>
+    [DataField]
+    public bool Replace = false;
+
+    public override void OnPlayerSpawn(EntityUid uid,
+        IComponentFactory factory,
+        IEntityManager entityManager,
+        ISerializationManager serializationManager)
+    {
+        if (!entityManager.TryGetComponent<BodyComponent>(uid, out var body))
+            return;
+
+        var bodySystem = entityManager.System<SharedBodySystem>();
+        var whitelistSystem = entityManager.System<EntityWhitelistSystem>();
+        var logManager = IoCManager.Resolve<IAdminLogManager>();
+
+        foreach (var (organId, _) in bodySystem.GetBodyOrgans(uid, body))
+        {
+            if (!entityManager.TryGetComponent<MetabolizerComponent>(organId, out var metabolizer)
+                || whitelistSystem.IsWhitelistFail(Whitelist, organId))
+                continue;
+
+            if (Replace || metabolizer.MetabolizerTypes == null)
+                metabolizer.MetabolizerTypes = Metabolizers;
+            else
+                metabolizer.MetabolizerTypes.UnionWith(Metabolizers);
+
+            logManager.Add(LogType.Hunger,
+                LogImpact.Low,
+                $"Added metabolizers {string.Join(",", Metabolizers)} to {entityManager.ToPrettyString(organId)} in {entityManager.ToPrettyString(uid)} (REPLACE: {Replace}). New metabolizer list: {string.Join(",", metabolizer.MetabolizerTypes)}");
+        }
+    }
+}

--- a/Content.Shared/Atmos/Rotting/RottingComponent.cs
+++ b/Content.Shared/Atmos/Rotting/RottingComponent.cs
@@ -1,3 +1,13 @@
+// SPDX-FileCopyrightText: 2023 Kara <lunarautomaton6@gmail.com>
+// SPDX-FileCopyrightText: 2023 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2024 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2024 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
+// SPDX-FileCopyrightText: 2025 portfiend <109661617+portfiend@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
+using Content.Shared._DEN.Chemistry;
 using Content.Shared.Damage;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
@@ -9,7 +19,7 @@ namespace Content.Shared.Atmos.Rotting;
 /// Only the current stage is networked to the client.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentPause]
-[Access(typeof(SharedRottingSystem))]
+[Access(typeof(SharedRottingSystem), typeof(SharedReplaceSolutionSystem))]
 public sealed partial class RottingComponent : Component
 {
     /// <summary>

--- a/Content.Shared/Atmos/Rotting/SharedRottingSystem.cs
+++ b/Content.Shared/Atmos/Rotting/SharedRottingSystem.cs
@@ -1,4 +1,13 @@
-﻿using Content.Shared.Examine;
+// SPDX-FileCopyrightText: 2024 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2024 Kara <lunarautomaton6@gmail.com>
+// SPDX-FileCopyrightText: 2024 VMSolidus <evilexecutive@gmail.com>
+// SPDX-FileCopyrightText: 2024 XavierSomething <tylernguyen203@gmail.com>
+// SPDX-FileCopyrightText: 2025 portfiend <109661617+portfiend@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
+using Content.Shared.Examine;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
@@ -6,6 +15,8 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.Rejuvenate;
 using Robust.Shared.Containers;
 using Robust.Shared.Timing;
+using JetBrains.Annotations;
+using Content.Shared.Nutrition.Components;
 
 namespace Content.Shared.Atmos.Rotting;
 
@@ -50,16 +61,8 @@ public abstract class SharedRottingSystem : EntitySystem
 
     private void OnPerishableExamined(Entity<PerishableComponent> perishable, ref ExaminedEvent args)
     {
-        int stage = PerishStage(perishable, MaxStages);
-        if (stage < 1 || stage > MaxStages)
-        {
-            // We dont push an examined string if it hasen't started "perishing" or it's already rotting
-            return;
-        }
-
-        var isMob = HasComp<MobStateComponent>(perishable);
-        var description = "perishable-" + stage + (!isMob ? "-nonmob" : string.Empty);
-        args.PushMarkup(Loc.GetString(description, ("target", Identity.Entity(perishable, EntityManager))));
+        var examineText = GetPerishableExamineText(perishable);
+        args.PushMarkup(examineText);
     }
 
     private void OnShutdown(EntityUid uid, RottingComponent component, ComponentShutdown args)
@@ -82,9 +85,33 @@ public abstract class SharedRottingSystem : EntitySystem
         RemCompDeferred<RottingComponent>(uid);
     }
 
-    private void OnExamined(EntityUid uid, RottingComponent component, ExaminedEvent args)
+    private void OnExamined(Entity<RottingComponent> rotting, ref ExaminedEvent args)
     {
-        var stage = RotStage(uid, component);
+        var examineText = GetRottingExamineText(rotting);
+        args.PushMarkup(examineText);
+    }
+
+    [PublicAPI]
+    public string GetPerishableExamineText(Entity<PerishableComponent> entity)
+    {
+        var stage = PerishStage(entity, MaxStages);
+        Log.Info($"Rotting stage : {stage}");
+        if (stage < 1 || stage > MaxStages)
+            return string.Empty;
+
+        var suffix = stage.ToString();
+        if (HasComp<MobStateComponent>(entity))
+            suffix += "-nonmob";
+
+        var description = "perishable-" + suffix;
+        return Loc.GetString(description, ("target", Identity.Entity(entity, EntityManager)));
+    }
+
+    [PublicAPI]
+    public string GetRottingExamineText(Entity<RottingComponent> entity)
+    {
+        var comp = entity.Comp;
+        var stage = RotStage(entity, comp);
         var description = stage switch
         {
             >= 2 => "rotting-extremely-bloated",
@@ -92,10 +119,10 @@ public abstract class SharedRottingSystem : EntitySystem
             _ => "rotting-rotting"
         };
 
-        if (!HasComp<MobStateComponent>(uid))
+        if (!HasComp<MobStateComponent>(entity))
             description += "-nonmob";
 
-        args.PushMarkup(Loc.GetString(description, ("target", Identity.Entity(uid, EntityManager))));
+        return Loc.GetString(description, ("target", Identity.Entity(entity, EntityManager)));
     }
 
     /// <summary>
@@ -160,6 +187,125 @@ public abstract class SharedRottingSystem : EntitySystem
 
         else
             rotting.TotalRotTime = total - perishable.RotAfter;
+    }
+
+    /// <summary>
+    /// Transfers accumulated rot from one entity to another, scaling the time proportioanlly if needed.
+    /// Does not transfer rotting level; use TransferRot for that.
+    /// </summary>
+    /// <param name="perishableFrom">The entity to transfer rot accumulation from.</param>
+    /// <param name="perishableTo">The entity whose rot accumulation is being replaced.</param>
+    /// <param name="proportional">Whether the rot accumulation on the receiving entity should be relative to its own expiration date.</param>
+    /// <param name="butcherableFrom">Optional, ButcherableComponent on the "from" entity. The FreshnessIncrease field of the component is used to add a flat modifier to the freshness transfer time.</param>
+    [PublicAPI]
+    public void TransferFreshness(EntityUid fromId,
+        PerishableComponent perishableFrom,
+        PerishableComponent perishableTo,
+        bool proportional = true,
+        ButcherableComponent? butcherableFrom = null)
+    {
+        TimeSpan newRotAccumulator = perishableFrom.RotAccumulator;
+
+        if (proportional)
+        {
+            var ratio = perishableFrom.RotAccumulator / perishableFrom.RotAfter;
+            newRotAccumulator = perishableTo.RotAfter * ratio;
+        }
+
+        if (butcherableFrom != null && !HasComp<RottingComponent>(fromId))
+            newRotAccumulator -= butcherableFrom.FreshnessIncrease;
+
+        if (newRotAccumulator < TimeSpan.Zero)
+            newRotAccumulator = TimeSpan.Zero;
+
+        perishableTo.RotAccumulator = newRotAccumulator;
+    }
+
+    /// <summary>
+    /// Transfers accumulated rot from one entity to another, scaling the time proportioanlly if needed.
+    /// Does not transfer rotting level; use TransferRot for that.
+    /// </summary>
+    /// <param name="fromId">The entity to transfer rot accumulation from.</param>
+    /// <param name="toId">The entity whose rot accumulation should be replaced.</param>
+    /// <param name="proportional">Whether the rot accumulation on the receiving entity should be relative to its own expiration date.</param>
+    /// <param name="butcherableFrom">Optional, ButcherableComponent on the "from" entity. The FreshnessIncrease field of the component is used to add a flat modifier to the freshness transfer time.</param>
+    [PublicAPI]
+    public void TransferFreshness(EntityUid fromId,
+        EntityUid toId,
+        bool proportional = true,
+        ButcherableComponent? butcherableFrom = null)
+    {
+        if (!TryComp<PerishableComponent>(fromId, out var perishableFrom)
+            || !TryComp<PerishableComponent>(toId, out var perishableTo))
+            return;
+
+        TransferFreshness(fromId, perishableFrom, perishableTo, proportional, butcherableFrom);
+    }
+
+    /// <summary>
+    /// Transfers rotting amount from a rotten entity to a receiving entity.
+    /// If the receiver is not already rotting, it will gain RottingComponent from this operation.
+    /// </summary>
+    /// <param name="rottingFrom">RottenComponent on the rotting entity.</param>
+    /// <param name="perishableFrom">PerishableComponent on the rotting entity.</param>
+    /// <param name="toId">The entity ID that will have its rot stage set.</param>
+    /// <param name="perishableTo">PerishableComponent on the "to" entity.</param>
+    /// <param name="proportional">Whether rot stage transferred should be proportional to the expiration time of the target entity.</param>
+    [PublicAPI]
+    public void TransferRotStage(RottingComponent rottingFrom,
+        PerishableComponent perishableFrom,
+        EntityUid toId,
+        PerishableComponent? perishableTo,
+        bool proportional = true)
+    {
+        var rottingTo = EnsureComp<RottingComponent>(toId);
+
+        if (!proportional || !Resolve(toId, ref perishableTo, false))
+        {
+            rottingTo.TotalRotTime = rottingFrom.TotalRotTime;
+            return;
+        }
+
+        var ratio = rottingFrom.TotalRotTime / perishableFrom.RotAfter;
+        rottingTo.TotalRotTime = perishableTo.RotAfter * ratio;
+    }
+
+    
+    /// <summary>
+    /// Transfers rotting amount from a rotten entity to a receiving entity.
+    /// If the receiver is not already rotting, it will gain RottingComponent from this operation.
+    /// </summary>
+    /// <param name="fromId">The entity ID that will transfer its rot stage.</param>
+    /// <param name="toId">The entity ID that will have its rot stage set.</param>
+    /// <param name="rottingFrom">RottenComponent on the rotting entity.</param>
+    /// <param name="proportional">Whether rot stage transferred should be proportional to the expiration time of the target entity.</param>
+    [PublicAPI]
+    public void TransferRotStage(EntityUid fromId,
+        EntityUid toId,
+        RottingComponent rottingFrom,
+        bool proportional = true)
+    {
+        if (!TryComp<PerishableComponent>(fromId, out var perishableFrom)
+            || !TryComp<PerishableComponent>(toId, out var perishableTo))
+            return;
+
+        TransferRotStage(rottingFrom, perishableFrom, toId, perishableTo, proportional);
+    }
+
+    /// <summary>
+    /// Transfers rotting amount from a rotten entity to a receiving entity.
+    /// If the receiver is not already rotting, it will gain RottingComponent from this operation.
+    /// </summary>
+    /// <param name="fromId">The entity ID that will transfer its rot stage.</param>
+    /// <param name="toId">The entity ID that will have its rot stage set.</param>
+    /// <param name="proportional">Whether rot stage transferred should be proportional to the expiration time of the target entity.</param>
+    [PublicAPI]
+    public void TransferRotStage(EntityUid fromId, EntityUid toId, bool proportional = true)
+    {
+        if (!TryComp<RottingComponent>(fromId, out var rottingFrom))
+            return;
+
+        TransferRotStage(fromId, toId, rottingFrom, proportional);
     }
 
     /// <summary>

--- a/Content.Shared/Chemistry/Components/Solution.cs
+++ b/Content.Shared/Chemistry/Components/Solution.cs
@@ -1,3 +1,39 @@
+// SPDX-FileCopyrightText: 2019 ZelteHonor <gabrieldionbouchard@gmail.com>
+// SPDX-FileCopyrightText: 2020 PrPleGoo <PrPleGoo@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2020 PrPleGoo <felix.leeuwen@gmail.com>
+// SPDX-FileCopyrightText: 2020 Tyler Young <tyler.young@impromptu.ninja>
+// SPDX-FileCopyrightText: 2020 Víctor Aguilera Puerto <zddm@outlook.es>
+// SPDX-FileCopyrightText: 2020 moneyl <8206401+Moneyl@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2020 nuke <47336974+nuke-makes-games@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2021 Acruid <shatter66@gmail.com>
+// SPDX-FileCopyrightText: 2021 Paul <ritter.paul1+git@googlemail.com>
+// SPDX-FileCopyrightText: 2021 Paul Ritter <ritter.paul1@googlemail.com>
+// SPDX-FileCopyrightText: 2021 TemporalOroboros <TemporalOroboros@gmail.com>
+// SPDX-FileCopyrightText: 2021 Vera Aguilera Puerto <gradientvera@outlook.com>
+// SPDX-FileCopyrightText: 2021 Vera Aguilera Puerto <zddm@outlook.es>
+// SPDX-FileCopyrightText: 2021 Ygg01 <y.laughing.man.y@gmail.com>
+// SPDX-FileCopyrightText: 2021 plinyvic <plinyvicgames@gmail.com>
+// SPDX-FileCopyrightText: 2021 py01 <60152240+collinlunn@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2022 Vera Aguilera Puerto <6766154+Zumorica@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2022 mirrorcult <lunarautomaton6@gmail.com>
+// SPDX-FileCopyrightText: 2022 wrexbe <81056464+wrexbe@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2023 Arimah <arimah42@gmail.com>
+// SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2023 EnDecc <33369477+Endecc@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2023 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2023 Psychpsyo <60073468+Psychpsyo@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2023 TemporalOroboros <temporaloroboros@gmail.com>
+// SPDX-FileCopyrightText: 2023 Visne <39844191+Visne@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2023 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2024 DEATHB4DEFEAT <77995199+DEATHB4DEFEAT@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2024 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
+// SPDX-FileCopyrightText: 2024 Skye <57879983+Rainbeon@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2024 neuPanda <chriseparton@gmail.com>
+// SPDX-FileCopyrightText: 2025 portfiend <109661617+portfiend@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.FixedPoint;
 using JetBrains.Annotations;
@@ -580,6 +616,22 @@ namespace Content.Shared.Chemistry.Components
             return sol;
         }
 
+        public Solution SplitSolutionWithout(FixedPoint2 toTake, IEnumerable<ReagentId> excludedPrototypes)
+        {
+            var excluded = excludedPrototypes
+                .Select(reagentId => reagentId.Prototype)
+                .ToArray();
+            return SplitSolutionWithout(toTake, excluded);
+        }
+
+        public Solution SplitSolutionWithout(FixedPoint2 toTake, IEnumerable<ProtoId<ReagentPrototype>> excludedPrototypes)
+        {
+            var excluded = excludedPrototypes
+                .Select(protoId => protoId.ToString())
+                .ToArray();
+            return SplitSolutionWithout(toTake, excluded);
+        }
+
         /// <summary>
         /// Splits a solution without the specified reagent prototypes.
         /// </summary>
@@ -606,6 +658,22 @@ namespace Content.Shared.Chemistry.Components
             }
 
             return sol;
+        }
+
+        public Solution SplitSolutionWithOnly(FixedPoint2 toTake, IEnumerable<ReagentId> includedPrototypes)
+        {
+            var included = includedPrototypes
+                .Select(reagentId => reagentId.Prototype)
+                .ToArray();
+            return SplitSolutionWithout(toTake, included);
+        }
+
+        public Solution SplitSolutionWithOnly(FixedPoint2 toTake, IEnumerable<ProtoId<ReagentPrototype>> includedPrototypes)
+        {
+            var included = includedPrototypes
+                .Select(protoId => protoId.ToString())
+                .ToArray();
+            return SplitSolutionWithOnly(toTake, included);
         }
 
         public Solution SplitSolution(FixedPoint2 toTake)

--- a/Content.Shared/Kitchen/Components/KitchenSpikeComponent.cs
+++ b/Content.Shared/Kitchen/Components/KitchenSpikeComponent.cs
@@ -1,4 +1,13 @@
+// SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2023 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 portfiend <109661617+portfiend@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
+using Content.Shared.Nutrition.Components;
 using Robust.Shared.Audio;
+using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
 
@@ -18,12 +27,22 @@ public sealed partial class KitchenSpikeComponent : Component
     public List<string>? PrototypesToSpawn;
 
     // TODO: Spiking alive mobs? (Replace with uid) (deal damage to their limbs on spiking, kill on first butcher attempt?)
+    [ViewVariables]
+    public Container SpikeContainer = default!;
+    // Note: This is not the "real" entity being spiked, but a "virtual entity"
+    // containing only relevant components instead. I am pretty uncertain about the inherent
+    // unpredictability of spiking entities who have a bunch of active systems running on them,
+    // and I don't want to find out.
+
     public string MeatSource1p = "?";
     public string MeatSource0 = "?";
     public string Victim = "?";
 
     // Prevents simultaneous spiking of two bodies (could be replaced with CancellationToken, but I don't see any situation where Cancel could be called)
     public bool InUse;
+
+    [DataField]
+    public string ContainerName = "spike";
 
     [Serializable, NetSerializable]
     public enum KitchenSpikeVisuals : byte

--- a/Content.Shared/Nutrition/Components/ButcherableComponent.cs
+++ b/Content.Shared/Nutrition/Components/ButcherableComponent.cs
@@ -1,3 +1,20 @@
+// SPDX-FileCopyrightText: 2020 20kdc <asdd2808@gmail.com>
+// SPDX-FileCopyrightText: 2021 Acruid <shatter66@gmail.com>
+// SPDX-FileCopyrightText: 2021 FoLoKe <36813380+FoLoKe@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2021 Paul Ritter <ritter.paul1@googlemail.com>
+// SPDX-FileCopyrightText: 2021 ShadowCommander <10494922+ShadowCommander@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2021 Visne <39844191+Visne@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2021 mirrorcult <notzombiedude@gmail.com>
+// SPDX-FileCopyrightText: 2022 mirrorcult <lunarautomaton6@gmail.com>
+// SPDX-FileCopyrightText: 2022 wrexbe <81056464+wrexbe@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2023 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2024 Mnemotechnican <69920617+Mnemotechnician@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 portfiend <109661617+portfiend@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
 using Content.Shared.Storage;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
@@ -24,6 +41,22 @@ namespace Content.Shared.Nutrition.Components
         /// </summary>
         [ViewVariables]
         public bool BeingButchered;
+
+        /// <summary>
+        /// Whether or not butchery products inherit freshness/rotting level of the thing being butchered.
+        /// </summary>
+        [DataField, ViewVariables(VVAccess.ReadWrite)]
+        public bool SpawnedInheritFreshness = true;
+
+        /// <summary>
+        /// For products that inherit the butcherable entity's freshness, this is how much extra time
+        /// you get before the item spoils, as a flat number.
+        /// For example: If a corpse spoils in 10 minutes, and meat spoils in 5 minutes, and the corpse
+        /// has 6 minutes on its rotting timer, the meat will have 60% freshness * 5 minutes = 3 minutes,
+        /// plus one minute of flat "freshness increase" that brings its Perishable time elapsed down to 2 minutes.
+        /// </summary>
+        [DataField, ViewVariables(VVAccess.ReadWrite)]
+        public TimeSpan FreshnessIncrease = TimeSpan.FromMinutes(1.0);
     }
 
     [Serializable, NetSerializable]

--- a/Content.Shared/_DEN/Chemistry/BaseReplaceSolutionComponent.cs
+++ b/Content.Shared/_DEN/Chemistry/BaseReplaceSolutionComponent.cs
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2025 portfiend <109661617+portfiend@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.FixedPoint;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Shared._DEN.Chemistry;
+
+/// <summary>
+/// Entities with this component may partially convert reagents into other reagents under certain conditions.
+/// </summary>
+public abstract partial class BaseReplaceSolutionComponent : Component
+{
+    /// <summary>
+    /// The name of the solution to replace.
+    /// </summary>
+    [DataField("solution", required: true), ViewVariables(VVAccess.ReadWrite)]
+    public string SolutionName = string.Empty;
+
+    /// <summary>
+    /// The solution to replace reagents from.
+    /// </summary>
+    [ViewVariables]
+    public Entity<SolutionComponent>? SolutionRef = null;
+
+    /// <summary>
+    /// A list of reagent replacements to perform. Can have multiple replacements, for example,
+    /// replacing every reagent in a solution with something else.
+    /// </summary>
+
+    [DataField("replacements"), ViewVariables(VVAccess.ReadWrite)]
+    public List<SolutionReplacement> Replacements = default!;
+
+    /// <summary>
+    /// Gets a list of all reagent IDs that are considering "rot byproducts", and thus
+    /// should not be replaced.
+    /// </summary>
+    /// <returns>List of rot byproduct reagent IDs.</returns>
+    public HashSet<ReagentId> ReplacementReagentIds()
+    {
+        HashSet<ReagentId> reagentIds = new HashSet<ReagentId>();
+
+        foreach (var replacement in Replacements)
+        {
+            if (replacement.ReplacementSolution.Contents.Count == 0)
+                continue;
+
+            foreach (var reagent in replacement.ReplacementSolution.Contents)
+            {
+                reagentIds.Add(reagent.Reagent);
+            }
+        }
+
+        return reagentIds;
+    }
+}
+
+/// <summary>
+/// An entity that will replace its solution every given interval.
+/// </summary>
+public abstract partial class BaseReplaceSolutionIntervalComponent : BaseReplaceSolutionComponent
+{
+    /// <summary>
+    /// How long it takes to replace the solution once.
+    /// </summary>
+    [DataField("duration"), ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan Duration = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// The time when the next replacement will occur.
+    /// </summary>
+    [DataField("nextChargeTime", customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan NextReplaceTime = TimeSpan.FromSeconds(0);
+}
+
+/// <summary>
+/// A data definition for specifying what reagents get replaced, and how much.
+/// </summary>
+
+[DataDefinition]
+public sealed partial class SolutionReplacement
+{
+    /// <summary>
+    /// The reagent(s) to be replaced in the solution.
+    /// </summary>
+    [DataField("solution", required: true), ViewVariables(VVAccess.ReadWrite)]
+    public Solution ReplacementSolution = default!;
+
+    /// <summary>
+    /// How much of the original solution should be reduced each cycle.
+    /// </summary>
+
+    [DataField("amount", required: true), ViewVariables(VVAccess.ReadWrite)]
+    public FixedPoint2 Amount = FixedPoint2.Zero;
+
+    /// <summary>
+    /// When specified, this only replaces the given reagents.
+    /// </summary>
+    [DataField("whitelist"), ViewVariables(VVAccess.ReadWrite)]
+    public List<ProtoId<ReagentPrototype>>? Whitelist = default!;
+}

--- a/Content.Shared/_DEN/Chemistry/ReplaceSolutionWhenRottenComponent.cs
+++ b/Content.Shared/_DEN/Chemistry/ReplaceSolutionWhenRottenComponent.cs
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2025 portfiend <109661617+portfiend@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._DEN.Chemistry;
+
+/// <summary>
+/// A component that works in tandem with <see cref="RottingComponent"/>. When this entity is rotten,
+/// the solution with the given name will be replaced with a given other solution.
+/// For example, rotting corpses may build up gastrotoxin.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ReplaceSolutionWhenRottenComponent : BaseReplaceSolutionIntervalComponent
+{ }

--- a/Content.Shared/_DEN/Chemistry/SharedReplaceSolutionSystem.cs
+++ b/Content.Shared/_DEN/Chemistry/SharedReplaceSolutionSystem.cs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2025 portfiend <109661617+portfiend@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
+namespace Content.Shared._DEN.Chemistry;
+
+public abstract class SharedReplaceSolutionSystem : EntitySystem
+{ }

--- a/Content.Shared/_DEN/Kitchen/SharedButcherySystem.cs
+++ b/Content.Shared/_DEN/Kitchen/SharedButcherySystem.cs
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2025 portfiend <109661617+portfiend@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
+using Content.Shared.Atmos.Rotting;
+using Content.Shared.Nutrition.Components;
+using Content.Shared.Storage;
+using Robust.Shared.Random;
+
+namespace Content.Shared._DEN.Kitchen;
+
+public sealed class SharedButcherySystem : EntitySystem
+{
+    [Dependency] private readonly IRobustRandom _robustRandom = default!;
+    [Dependency] private readonly SharedRottingSystem _rotting = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    public EntityUid? SpawnButcherableProducts(EntityUid uid, ButcherableComponent butcher)
+    {
+        var spawnEntities = EntitySpawnCollection.GetSpawns(butcher.SpawnedEntities, _robustRandom);
+        var coords = _transform.GetMapCoordinates(uid);
+        EntityUid? lastEntity = null;
+
+        foreach (var proto in spawnEntities)
+        {
+            // distribute the spawned items randomly in a small radius around the origin
+            lastEntity = Spawn(proto, coords.Offset(_robustRandom.NextVector2(0.25f)));
+
+            if (butcher.SpawnedInheritFreshness)
+            {
+                _rotting.TransferFreshness(uid, lastEntity.Value, true, butcher);
+                _rotting.TransferRotStage(uid, lastEntity.Value, true);
+            }
+        }
+
+        return lastEntity;
+    }
+}

--- a/Resources/Locale/en-US/_DEN/metabolism/metabolizer-types.ftl
+++ b/Resources/Locale/en-US/_DEN/metabolism/metabolizer-types.ftl
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2025 portfiend <109661617+portfiend@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
+metabolizer-type-detritivore = Detritivore

--- a/Resources/Locale/en-US/_DEN/traits/traits.ftl
+++ b/Resources/Locale/en-US/_DEN/traits/traits.ftl
@@ -9,7 +9,6 @@
 
 
 trait-name-Detritivore = Detritivore
-trait-description-Detritivore = Your hardy digestive system is well-equipped for rotting food.
-    Gastrotoxin and mold have no ill effects on you, and will restore your hunger.
-    You can also digest uncooked animal proteins (raw meat) if you do not already have the ability
-    to do so, and even rotting animal corpses will be safe for consumption.
+trait-description-Detritivore = Through some gruesome biomechanical augmentation or
+freak mutation, you are able to metabolized raw flesh, rotting or otherwise, as well
+as mold-infested foods.

--- a/Resources/Locale/en-US/_DEN/traits/traits.ftl
+++ b/Resources/Locale/en-US/_DEN/traits/traits.ftl
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: 2025 Blitz <73762869+BlitzTheSquishy@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Rosycup <178287475+Rosycup@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Tabitha <64847293+KyuPolaris@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 foxcurl <kitshoffeitt@gmail.com>
+# SPDX-FileCopyrightText: 2025 portfiend <109661617+portfiend@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
+trait-name-Heavyweight = Heavyweight
+trait-description-Heavyweight =
+    You are naturally heavier than other representatives of your species. Your body density is increased by 1/3 of normal.
+    Note: [color=red]this will not display in the character creation menu, and will only have effect in-game.[/color]
+
+trait-name-UltraHeavyweight = Ultra Heavyweight
+trait-description-UltraHeavyweight =
+    You are naturally a lot heavier than other representatives of your species. Your body density is increased by double of normal.
+    Note: [color=red]this will not display in the character creation menu, and will only have effect in-game.[/color]
+
+trait-name-UltraLightweight = Ultra Lightweight
+trait-description-UltraLightweight =
+    You are naturally a lot lighter than other representatives of your species. Your body density is decresed by 2/3 of normal.
+    Note: [color=red]this will not display in the character creation menu, and will only have effect in-game.[/color]
+
+trait-name-ZeroGTraining = Zero G Training
+trait-description-ZeroGTraining =
+    Either through training or just through personal experience of the Gravity Generator being blown up over and over again,
+    you are proficient in the ways of floating in zero gravity. You gain an increased speed manuvering in Zero-G environments.
+
+trait-name-ZeroGAverse = Zero G Averse
+trait-description-ZeroGAverse =
+    You very much prefer to have your boots on the ground and/or are terrified of the feeling of weightlessness. While under
+    the effects of Zero-G you are significantly slower than the normal spessman
+
+trait-name-HoneyProducer = Honey Stomach
+trait-description-HoneyProducer = Your abdomen contains an extra stomach that processes nutrients into honey.
+
+trait-name-TailWag = Tail Wag
+trait-description-TailWag =
+    Your species has the innate ability to wag their tails, often used as an avenue to express untold emotions.
+    Note: [color=red]This will only work if the tail marking your character uses has wagging animations available.[/color]
+
+trait-name-FastMetabolism = Fast Metabolism
+trait-description-FastMetabolism = You naturally have a faster metabolism, burning through calories faster than average, requiring more food to satisfy your hunger.
+
+trait-name-Alaseta = Alaseta
+trait-description-Alaseta = A horrifying mix of Sol Common and Canilunzt, the language is loosely remembles the structure Sol Common with alot more yapping, snarling, and growling.
+
+trait-name-Detritivore = Detritivore
+trait-description-Detritivore = Your hardy digestive system is well-equipped for rotting food.
+    Gastrotoxin and mold have no ill effects on you, and will restore your hunger.
+    You can also digest uncooked animal proteins (raw meat) if you do not already have the ability
+    to do so, and even rotting animal corpses will be safe for consumption.
+
+trait-name-VoxPidgin = Vox-Pidgin
+trait-description-VoxPidgin =
+    The common tongue of the various Vox ships making up the Shoal. It sounds like chaotic shrieking to everyone else.
+    The sounds in this language can only be produced by a Vox's unique Syrinx.
+    Note: [color=red]This trait only allows you to understand Vox-Pidgin. You will not be able to speak it.[/color]
+
+trait-name-SharpTeeth = Sharp Teeth
+trait-description-SharpTeeth =
+    You were born with or have had your teeth modified to be sharper.
+    These could come from gene modifications, a genetic legacy,
+    or even custom made implants designed to turn teeth into tiny knives.
+    Your unarmed melee attacks deal Piercing damage instead of the standard damage type for your species.
+    This has no effect on damage dealt with any form of armed melee.
+
+trait-name-HandsFreePulling = Hands Free Pulling
+trait-description-HandsFreePulling =
+    You were born with or have had your tail modified to be stronger than normal or have aquired
+    some sort of telekinesis that allows you to drag things around without your hands.
+    These could come from gene modifications, inherited genetics,
+    or even custom implantations or modifications.
+    You're able to drag things around without using your hands due to your abnormally strong tail or other modifications.
+
+trait-name-BloodExaminer = Blood Smell
+trait-description-BloodExaminer =
+    You can [color=yellow]identify the blood chemical of mobs[/color] when you stand close enough to them.
+    Note that this trait [color=orange]does not detect other chemicals in their blood stream[/color], only what
+    the mob's blood stream is actually made of - such as [color=lightblue]synth blood[/color] or [color=lightblue]insect blood[/color].
+
+trait-name-Aural = Aural
+trait-description-Aural =
+    The songlike language of ancient thaven society, known for its fluid rhythm, melodic tones, and dense vocalizations. It's often described by outsiders as speaking in tongues.
+    Naturally resonant underwater, exposure to Aural has been reported to trigger strange sensory effects in non-thaven listeners - most commonly a soft tingling behind the ears.
+    Though hauntingly beautiful, it is notoriously difficult to learn; thaven polyglots often switch languages mid-conversation to spare others from butchering the sound.
+
+trait-name-ThavenMoods = Thaven Moods
+trait-description-ThavenMoods =
+    Your brain has a [color=yellow]unique structure[/color] that is susceptible to cosmic interference.
+    You are subject to a variety of [color=orange]moods[/color], not unlike [color=lightblue]cyborg laws[/color] - they should be
+    followed strictly, and failure to adhere to your moods should be [color=red]corrected[/color].
+
+    Note that this trait renders you vulnerable to [color=orange]external circumstances[/color] that may
+    drastically alter your character's personality - including [color=yellow]ion storms[/color] and (if
+    consented) [color=red]Emagging[/color] when incapacitated. [color=orange][italic]
+
+    (This is the "intended playstyle" of Thaven; this trait is opt-in due to its ability to modify
+    your character out of your control. Some moods may have moderate-to-high impact.)[/italic][/color]

--- a/Resources/Locale/en-US/_DEN/traits/traits.ftl
+++ b/Resources/Locale/en-US/_DEN/traits/traits.ftl
@@ -7,94 +7,9 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 
-trait-name-Heavyweight = Heavyweight
-trait-description-Heavyweight =
-    You are naturally heavier than other representatives of your species. Your body density is increased by 1/3 of normal.
-    Note: [color=red]this will not display in the character creation menu, and will only have effect in-game.[/color]
-
-trait-name-UltraHeavyweight = Ultra Heavyweight
-trait-description-UltraHeavyweight =
-    You are naturally a lot heavier than other representatives of your species. Your body density is increased by double of normal.
-    Note: [color=red]this will not display in the character creation menu, and will only have effect in-game.[/color]
-
-trait-name-UltraLightweight = Ultra Lightweight
-trait-description-UltraLightweight =
-    You are naturally a lot lighter than other representatives of your species. Your body density is decresed by 2/3 of normal.
-    Note: [color=red]this will not display in the character creation menu, and will only have effect in-game.[/color]
-
-trait-name-ZeroGTraining = Zero G Training
-trait-description-ZeroGTraining =
-    Either through training or just through personal experience of the Gravity Generator being blown up over and over again,
-    you are proficient in the ways of floating in zero gravity. You gain an increased speed manuvering in Zero-G environments.
-
-trait-name-ZeroGAverse = Zero G Averse
-trait-description-ZeroGAverse =
-    You very much prefer to have your boots on the ground and/or are terrified of the feeling of weightlessness. While under
-    the effects of Zero-G you are significantly slower than the normal spessman
-
-trait-name-HoneyProducer = Honey Stomach
-trait-description-HoneyProducer = Your abdomen contains an extra stomach that processes nutrients into honey.
-
-trait-name-TailWag = Tail Wag
-trait-description-TailWag =
-    Your species has the innate ability to wag their tails, often used as an avenue to express untold emotions.
-    Note: [color=red]This will only work if the tail marking your character uses has wagging animations available.[/color]
-
-trait-name-FastMetabolism = Fast Metabolism
-trait-description-FastMetabolism = You naturally have a faster metabolism, burning through calories faster than average, requiring more food to satisfy your hunger.
-
-trait-name-Alaseta = Alaseta
-trait-description-Alaseta = A horrifying mix of Sol Common and Canilunzt, the language is loosely remembles the structure Sol Common with alot more yapping, snarling, and growling.
 
 trait-name-Detritivore = Detritivore
 trait-description-Detritivore = Your hardy digestive system is well-equipped for rotting food.
     Gastrotoxin and mold have no ill effects on you, and will restore your hunger.
     You can also digest uncooked animal proteins (raw meat) if you do not already have the ability
     to do so, and even rotting animal corpses will be safe for consumption.
-
-trait-name-VoxPidgin = Vox-Pidgin
-trait-description-VoxPidgin =
-    The common tongue of the various Vox ships making up the Shoal. It sounds like chaotic shrieking to everyone else.
-    The sounds in this language can only be produced by a Vox's unique Syrinx.
-    Note: [color=red]This trait only allows you to understand Vox-Pidgin. You will not be able to speak it.[/color]
-
-trait-name-SharpTeeth = Sharp Teeth
-trait-description-SharpTeeth =
-    You were born with or have had your teeth modified to be sharper.
-    These could come from gene modifications, a genetic legacy,
-    or even custom made implants designed to turn teeth into tiny knives.
-    Your unarmed melee attacks deal Piercing damage instead of the standard damage type for your species.
-    This has no effect on damage dealt with any form of armed melee.
-
-trait-name-HandsFreePulling = Hands Free Pulling
-trait-description-HandsFreePulling =
-    You were born with or have had your tail modified to be stronger than normal or have aquired
-    some sort of telekinesis that allows you to drag things around without your hands.
-    These could come from gene modifications, inherited genetics,
-    or even custom implantations or modifications.
-    You're able to drag things around without using your hands due to your abnormally strong tail or other modifications.
-
-trait-name-BloodExaminer = Blood Smell
-trait-description-BloodExaminer =
-    You can [color=yellow]identify the blood chemical of mobs[/color] when you stand close enough to them.
-    Note that this trait [color=orange]does not detect other chemicals in their blood stream[/color], only what
-    the mob's blood stream is actually made of - such as [color=lightblue]synth blood[/color] or [color=lightblue]insect blood[/color].
-
-trait-name-Aural = Aural
-trait-description-Aural =
-    The songlike language of ancient thaven society, known for its fluid rhythm, melodic tones, and dense vocalizations. It's often described by outsiders as speaking in tongues.
-    Naturally resonant underwater, exposure to Aural has been reported to trigger strange sensory effects in non-thaven listeners - most commonly a soft tingling behind the ears.
-    Though hauntingly beautiful, it is notoriously difficult to learn; thaven polyglots often switch languages mid-conversation to spare others from butchering the sound.
-
-trait-name-ThavenMoods = Thaven Moods
-trait-description-ThavenMoods =
-    Your brain has a [color=yellow]unique structure[/color] that is susceptible to cosmic interference.
-    You are subject to a variety of [color=orange]moods[/color], not unlike [color=lightblue]cyborg laws[/color] - they should be
-    followed strictly, and failure to adhere to your moods should be [color=red]corrected[/color].
-
-    Note that this trait renders you vulnerable to [color=orange]external circumstances[/color] that may
-    drastically alter your character's personality - including [color=yellow]ion storms[/color] and (if
-    consented) [color=red]Emagging[/color] when incapacitated. [color=orange][italic]
-
-    (This is the "intended playstyle" of Thaven; this trait is opt-in due to its ability to modify
-    your character out of your control. Some moods may have moderate-to-high impact.)[/italic][/color]

--- a/Resources/Prototypes/Body/Organs/Animal/animal.yml
+++ b/Resources/Prototypes/Body/Organs/Animal/animal.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: BaseAnimalOrganUnGibbable
   parent: BaseItem
   abstract: true
@@ -93,12 +93,15 @@
   id: OrganMouseStomach
   parent: OrganAnimalStomach
   name: stomach
+  suffix: "mouse"
   categories: [ HideSpawnMenu ]
   components:
   - type: SolutionContainerManager
     solutions:
       stomach:
         maxVol: 30
+  - type: Metabolizer
+    metabolizerTypes: [ Animal, Detritivore ]
 
 - type: entity
   id: OrganAnimalLiver
@@ -136,6 +139,15 @@
     - id: Poison
     - id: Narcotic
   - type: Heart # Shitmed
+
+  
+- type: entity
+  id: OrganMouseHeart
+  parent: OrganAnimalHeart
+  suffix: "mouse"
+  components:
+  - type: Metabolizer
+    metabolizerTypes: [ Animal, Detritivore ]
 
 
 - type: entity

--- a/Resources/Prototypes/Body/Prototypes/Animal/animal.yml
+++ b/Resources/Prototypes/Body/Prototypes/Animal/animal.yml
@@ -1,4 +1,4 @@
-﻿- type: body
+- type: body
   id: Animal
   name: "animal"
   root: torso
@@ -33,7 +33,7 @@
         lungs: OrganAnimalLungs
         stomach: OrganMouseStomach
         liver: OrganAnimalLiver
-        heart: OrganAnimalHeart
+        heart: OrganMouseHeart
         kidneys: OrganAnimalKidneys
     legs:
       part: LegsAnimal

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/NPCs/nukiemouse.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/NPCs/nukiemouse.yml
@@ -92,6 +92,17 @@
           Quantity: 55
         - ReagentId: Fat
           Quantity: 5
+  - type: ReplaceSolutionWhenRotten
+    solution: food
+    duration: 1.2
+    replacements:
+      - solution:
+          reagents:
+          - ReagentId: GastroToxin
+            Quantity: 0.01 # 5u replaced after 600 seconds
+        whitelist:
+        - Nutriment
+        amount: 0.01
   - type: Butcherable
     spawned:
     - id: FoodMeat

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1,3 +1,131 @@
+# SPDX-FileCopyrightText: 2022 ShadowCommander <10494922+ShadowCommander@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 Stealthbomber16 <100171035+Stealthbomber16@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 T-Stalker <43253663+DogZeroX@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 TekuNut <13456422+TekuNut@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 Tomeno <Tomeno@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 Tomeno <tomeno@lulzsec.co.uk>
+# SPDX-FileCopyrightText: 2022 Vordenburg <114301317+Vordenburg@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 Willhelm53 <97707302+Willhelm53@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 ZeroDayDaemon <60460608+ZeroDayDaemon@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 Zymem <97173622+Zymem@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 biometricPsychography <cyclinglinguist@gmail.com>
+# SPDX-FileCopyrightText: 2022 fishfish458 <fishfish458>
+# SPDX-FileCopyrightText: 2022 hubismal <47284081+hubismal@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 keronshb <54602815+keronshb@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 lapatison <100279397+lapatison@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 metalgearsloth <comedian_vs_clown@hotmail.com>
+# SPDX-FileCopyrightText: 2022 metalgearsloth <metalgearsloth@gmail.com>
+# SPDX-FileCopyrightText: 2022 mirrorcult <lunarautomaton6@gmail.com>
+# SPDX-FileCopyrightText: 2022 rolfero <45628623+rolfero@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Alekshhh <44923899+Alekshhh@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Alex Evgrashin <aevgrashin@yandex.ru>
+# SPDX-FileCopyrightText: 2023 Brandon Hu <103440971+Brandon-Huu@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Colin-Tel <113523727+Colin-Tel@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Dakamakat <52600490+dakamakat@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Doru991 <75124791+Doru991@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 EEASAS <109891564+EEASAS@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Emisse <99158783+Emisse@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Fluffiest Floofers <thebluewulf@gmail.com>
+# SPDX-FileCopyrightText: 2023 GoodWheatley <109803540+GoodWheatley@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 HerCoyote23 <131214189+HerCoyote23@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 I.K <45953835+notquitehadouken@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Jackrost <jackrost@mail.ru>
+# SPDX-FileCopyrightText: 2023 Jezithyr <jezithyr@gmail.com>
+# SPDX-FileCopyrightText: 2023 Kara <lunarautomaton6@gmail.com>
+# SPDX-FileCopyrightText: 2023 Kit0vras <123590995+Kit0vras@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Lazzi0706 <49803294+Lazzi0706@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Lazzi0706 <lazzikrytskiy0706@gmail.com>
+# SPDX-FileCopyrightText: 2023 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Mr. 27 <45323883+27alaing@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Nairod <110078045+Nairodian@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Nim <128169402+Nimfar11@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 PHCodes <47927305+PHCodes@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 PixelTK <85175107+PixelTheKermit@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Repo <47093363+Titian3@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Simon <63975668+Simyon264@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Sir Winters <7543955+Owai-Seek@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Slava0135 <40753025+Slava0135@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Tox Cruize <141375638+TexCruize@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Tyzemol <85772526+Tyzemol@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Vasilis <vasilis@pikachu.systems>
+# SPDX-FileCopyrightText: 2023 Vasilis The Pikachu <vasilis@pikachu.systems>
+# SPDX-FileCopyrightText: 2023 Visne <39844191+Visne@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Whisper <121047731+QuietlyWhisper@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 brainfood1183 <113240905+brainfood1183@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 coolmankid12345 <55817627+coolmankid12345@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 coolmankid12345 <coolmankid12345@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 crazybrain23 <44417085+crazybrain23@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 deltanedas <@deltanedas:kde.org>
+# SPDX-FileCopyrightText: 2023 gus <august.eymann@gmail.ccom>
+# SPDX-FileCopyrightText: 2023 gus <august.eymann@gmail.com>
+# SPDX-FileCopyrightText: 2023 liltenhead <104418166+liltenhead@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 lzk <124214523+lzk228@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 lzk228 <124214523+lzk228@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 nikthechampiongr <32041239+nikthechampiongr@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 notquitehadouken <1isthisameme>
+# SPDX-FileCopyrightText: 2023 pofitlo <107665898+pofitlo@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 ravage <142820619+ravage123321@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 reverie collection <revsys413@gmail.com>
+# SPDX-FileCopyrightText: 2024 778b <33431126+778b@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Aiden <aiden@djkraz.com>
+# SPDX-FileCopyrightText: 2024 Alzore <140123969+Blackern5000@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Anzarot121 <116586144+Anzarot121@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Arendian <137322659+Arendian@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 BITTERLYNX <166083655+PaigeMaeForrest@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 DEATHB4DEFEAT <77995199+DEATHB4DEFEAT@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Dae <60460608+ZeroDayDaemon@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Debug <49997488+DebugOk@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Ed <96445749+TheShuEd@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Errant <35878406+Errant-4@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Fansana <116083121+Fansana@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Fansana <fansana95@googlemail.com>
+# SPDX-FileCopyrightText: 2024 FoxxoTrystan <45297731+FoxxoTrystan@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 FryOfDestiny <180878286+FryOfDestiny@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Ilya246 <57039557+Ilya246@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 IlyaElDunaev <154531074+IlyaElDunaev@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 LankLTE <135308300+LankLTE@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 LankLTE <135308300+lanklte@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 MilenVolf <63782763+MilenVolf@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Minemoder5000 <minemoder50000@gmail.com>
+# SPDX-FileCopyrightText: 2024 Mnemotechnican <69920617+Mnemotechnician@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Mr. 27 <45323883+Dutch-VanDerLinde@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Psychpsyo <60073468+Psychpsyo@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 SimpleStation14 <130339894+SimpleStation14@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Tayrtahn <tayrtahn@gmail.com>
+# SPDX-FileCopyrightText: 2024 Ubaser <134914314+UbaserB@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Ubaser <134914314+ubaserb@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Verm <32827189+Vermidia@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 beck-thompson <107373427+beck-thompson@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 deathride58 <deathride58@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 deltanedas <39013340+deltanedas@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 fox <daytimer253@gmail.com>
+# SPDX-FileCopyrightText: 2024 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 gluesniffler <linebarrelerenthusiast@gmail.com>
+# SPDX-FileCopyrightText: 2024 lunarcomets <140772713+lunarcomets@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 potato1234_x <79580518+potato1234x@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 sleepyyapril <flyingkarii@gmail.com>
+# SPDX-FileCopyrightText: 2024 themias <89101928+themias@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 zelezniciar1 <39102800+zelezniciar1@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Blitz <73762869+BlitzTheSquishy@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Eris <eris@erisws.com>
+# SPDX-FileCopyrightText: 2025 M3739 <47579354+M3739@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Rosycup <178287475+Rosycup@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Skubman <ba.fallaria@gmail.com>
+# SPDX-FileCopyrightText: 2025 Spatison <137375981+Spatison@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Tabitha <64847293+KyuPolaris@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 VMSolidus <evilexecutive@gmail.com>
+# SPDX-FileCopyrightText: 2025 musicman928 <106891103+musicman928@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 portfiend <109661617+portfiend@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 skyr0cket01 <skyr0cketz00m519@gmail.com>
+# SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
 - type: entity
   name: bat
   parent: [ SimpleMobBase, FlyingMobBase, MobCombat ]
@@ -403,6 +531,17 @@
         reagents:
         - ReagentId: Slime
           Quantity: 5
+  - type: ReplaceSolutionWhenRotten
+    solution: food
+    duration: 1.2
+    replacements:
+      - solution:
+          reagents:
+          - ReagentId: GastroToxin
+            Quantity: 0.01 # 5u replaced after 600 seconds
+        whitelist:
+        - Slime
+        amount: 0.01
   - type: Butcherable
     spawned:
     - id: FoodMeatSlime
@@ -2029,6 +2168,17 @@
         reagents:
         - ReagentId: UncookedAnimalProteins
           Quantity: 3
+  - type: ReplaceSolutionWhenRotten
+    solution: food
+    duration: 2
+    replacements:
+      - solution:
+          reagents:
+          - ReagentId: GastroToxin
+            Quantity: 0.01 # 3u replaced after 600 seconds
+        whitelist:
+        - UncookedAnimalProteins
+        amount: 0.01
   - type: Butcherable
     spawned:
     - id: FoodMeatRat
@@ -3792,6 +3942,17 @@
           Quantity: 55
         - ReagentId: Fat
           Quantity: 5
+  - type: ReplaceSolutionWhenRotten
+    solution: food
+    duration: 1.2
+    replacements:
+      - solution:
+          reagents:
+          - ReagentId: GastroToxin
+            Quantity: 0.01 # 5u replaced after 600 seconds
+        whitelist:
+        - Nutriment
+        amount: 0.01
   - type: Butcherable
     spawned:
     - id: FoodMeat

--- a/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
@@ -474,6 +474,17 @@
         reagents:
         - ReagentId: UncookedAnimalProteins
           Quantity: 3
+  - type: ReplaceSolutionWhenRotten
+    solution: food
+    duration: 2
+    replacements:
+      - solution:
+          reagents:
+          - ReagentId: GastroToxin
+            Quantity: 0.01 # 3u replaced after 600 seconds
+        whitelist:
+        - UncookedAnimalProteins
+        amount: 0.01
   - type: Butcherable
     spawned:
     - id: FoodMeatSnail

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
@@ -1,3 +1,48 @@
+# SPDX-FileCopyrightText: 2021 20kdc
+# SPDX-FileCopyrightText: 2021 Pieter-Jan Briers
+# SPDX-FileCopyrightText: 2021 Swept
+# SPDX-FileCopyrightText: 2021 SweptWasTaken
+# SPDX-FileCopyrightText: 2021 Vera Aguilera Puerto
+# SPDX-FileCopyrightText: 2021 Ygg01
+# SPDX-FileCopyrightText: 2022 CrudeWax
+# SPDX-FileCopyrightText: 2022 EmoGarbage404
+# SPDX-FileCopyrightText: 2022 Flipp Syder
+# SPDX-FileCopyrightText: 2022 Greenrock64
+# SPDX-FileCopyrightText: 2022 Moony
+# SPDX-FileCopyrightText: 2022 Peptide90
+# SPDX-FileCopyrightText: 2022 Radosvik
+# SPDX-FileCopyrightText: 2022 Rane
+# SPDX-FileCopyrightText: 2022 ZeroDayDaemon
+# SPDX-FileCopyrightText: 2022 mirrorcult
+# SPDX-FileCopyrightText: 2023 Kara
+# SPDX-FileCopyrightText: 2023 Kevin Zheng
+# SPDX-FileCopyrightText: 2023 Kit0vras
+# SPDX-FileCopyrightText: 2023 LankLTE
+# SPDX-FileCopyrightText: 2023 Leon Friedrich
+# SPDX-FileCopyrightText: 2023 Nemanja
+# SPDX-FileCopyrightText: 2023 Nim
+# SPDX-FileCopyrightText: 2023 Timothy Teakettle
+# SPDX-FileCopyrightText: 2023 Velcroboy
+# SPDX-FileCopyrightText: 2023 deltanedas
+# SPDX-FileCopyrightText: 2023 lzk
+# SPDX-FileCopyrightText: 2023 metalgearsloth
+# SPDX-FileCopyrightText: 2023 potato1234_x
+# SPDX-FileCopyrightText: 2024 Debug
+# SPDX-FileCopyrightText: 2024 Ed
+# SPDX-FileCopyrightText: 2024 Errant
+# SPDX-FileCopyrightText: 2024 IProduceWidgets
+# SPDX-FileCopyrightText: 2024 PoorMansDreams
+# SPDX-FileCopyrightText: 2024 SimpleStation14
+# SPDX-FileCopyrightText: 2024 deathride58
+# SPDX-FileCopyrightText: 2024 slarticodefast
+# SPDX-FileCopyrightText: 2025 Blitz
+# SPDX-FileCopyrightText: 2025 Hedera
+# SPDX-FileCopyrightText: 2025 Rosycup
+# SPDX-FileCopyrightText: 2025 portfiend
+# SPDX-FileCopyrightText: 2025 sleepyyapril
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
 # Base
 
 - type: entity
@@ -68,6 +113,18 @@
     entity: FoodMeatRotten
     # once it would say bloated, turn into the rotten prototype
     stage: 1
+  - type: ReplaceSolutionWhenRotten
+    solution: food
+    duration: 1.5
+    replacements:
+      - solution:
+          reagents:
+          - ReagentId: GastroToxin
+            Quantity: 0.02 # 4u replaced after 300 seconds
+        whitelist:
+        - Nutriment
+        - UncookedAnimalProteins
+        amount: 0.02
 
 # bruh
 - type: Tag

--- a/Resources/Prototypes/Entities/Structures/meat_spike.yml
+++ b/Resources/Prototypes/Entities/Structures/meat_spike.yml
@@ -1,4 +1,27 @@
-﻿- type: entity
+# SPDX-FileCopyrightText: 2021 20kdc <asdd2808@gmail.com>
+# SPDX-FileCopyrightText: 2021 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2021 FoLoKe <36813380+FoLoKe@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2021 Galactic Chimp <GalacticChimpanzee@gmail.com>
+# SPDX-FileCopyrightText: 2021 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
+# SPDX-FileCopyrightText: 2021 ShadowCommander <10494922+ShadowCommander@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
+# SPDX-FileCopyrightText: 2021 SweptWasTaken <sweptwastaken@protonmail.com>
+# SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
+# SPDX-FileCopyrightText: 2022 Peptide90 <78795277+Peptide90@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 Profane McBane <profanedbane+github@gmail.com>
+# SPDX-FileCopyrightText: 2022 metalgearsloth <comedian_vs_clown@hotmail.com>
+# SPDX-FileCopyrightText: 2023 Sir Winters <7543955+Owai-Seek@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 TemporalOroboros <TemporalOroboros@gmail.com>
+# SPDX-FileCopyrightText: 2023 lzk <124214523+lzk228@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Kara <lunarautomaton6@gmail.com>
+# SPDX-FileCopyrightText: 2025 portfiend <109661617+portfiend@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
+- type: entity
   id: KitchenSpike
   parent: BaseStructure
   name: meat spike
@@ -42,6 +65,10 @@
   - type: Transform
     noRot: true
   - type: KitchenSpike
+  - type: ContainerContainer
+    containers:
+      spike: !type:Container
+        ents: []
   - type: Anchorable
   - type: Pullable
   - type: Appearance

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -90,6 +90,10 @@
     Poison:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Detritivore
+          shouldHave: false
         damage:
           types:
             Poison: 2
@@ -97,7 +101,25 @@
         conditions:
         - !type:ReagentThreshold
           min: 2
+        - !type:OrganType
+          type: Detritivore
+          shouldHave: false
         probability: 0.2
+      - !type:PopupMessage
+        conditions:
+        - !type:OrganType
+          type: Detritivore
+          shouldHave: false
+        type: Local
+        visualType: MediumCaution
+        messages: [ "generic-reagent-effect-sick" ]
+        probability: 0.4
+    Food:
+      effects:
+      - !type:SatiateHunger
+        conditions:
+        - !type:OrganType
+          type: Detritivore
 
 - type: reagent
   id: Mold
@@ -112,9 +134,19 @@
     Poison:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Detritivore
+          shouldHave: false
         damage:
           types:
             Poison: 1
+    Food:
+      effects:
+      - !type:SatiateHunger
+        conditions:
+          - !type:OrganType
+            type: Detritivore
 
 - type: reagent
   id: PolytrinicAcid
@@ -502,10 +534,16 @@
         - !type:OrganType
           type: Animal
           shouldHave: false
+        - !type:OrganType # It'd be silly if you could stomach Rotting Food but not raw meat on its own.
+          type: Detritivore
+          shouldHave: false
       - !type:HealthChange
         conditions:
         - !type:OrganType
           type: Animal
+          shouldHave: false
+        - !type:OrganType
+          type: Detritivore
           shouldHave: false
         damage:
           types:
@@ -515,6 +553,9 @@
         - !type:OrganType
           type: Animal
           shouldHave: true
+        - !type:OrganType
+          type: Detritivore
+          shouldHave: false
         reagent: Protein
         amount: 0.5
       - !type:AdjustReagent

--- a/Resources/Prototypes/_DEN/Body/Organs/rodentia.yml
+++ b/Resources/Prototypes/_DEN/Body/Organs/rodentia.yml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2025 portfiend <109661617+portfiend@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
+- type: entity
+  id: OrganRodentiaStomach
+  parent: OrganAnimalStomach
+  suffix: "rodentia"
+  components:
+  - type: Metabolizer
+    metabolizerTypes: [ Animal, Detritivore ]

--- a/Resources/Prototypes/_DEN/Chemistry/metabolizer_types.yml
+++ b/Resources/Prototypes/_DEN/Chemistry/metabolizer_types.yml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2025 portfiend <109661617+portfiend@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
+
+- type: metabolizerType
+  id: Detritivore
+  name: metabolizer-type-detritivore

--- a/Resources/Prototypes/_DEN/Traits/metabolism.yml
+++ b/Resources/Prototypes/_DEN/Traits/metabolism.yml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 Jakumba
+# SPDX-FileCopyrightText: 2025 portfiend
+# SPDX-FileCopyrightText: 2025 sleepyyapril
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
+- type: trait
+  id: Detritivore
+  category: TraitsPhysicalBiological
+  points: -1
+  requirements:
+  - !type:CharacterJobRequirement
+    inverted: true
+    jobs:
+      - StationAi
+      - Borg
+      - MedicalBorg
+  - !type:CharacterSpeciesRequirement
+    inverted: true
+    species:
+      - IPC
+      - Rodentia
+  functions:
+  - !type:TraitAddMetabolizer
+    metabolizers:
+    - Detritivore

--- a/Resources/Prototypes/_DEN/Traits/metabolism.yml
+++ b/Resources/Prototypes/_DEN/Traits/metabolism.yml
@@ -7,7 +7,7 @@
 - type: trait
   id: Detritivore
   category: TraitsPhysicalBiological
-  points: -1
+  points: -3
   requirements:
   - !type:CharacterJobRequirement
     inverted: true

--- a/Resources/Prototypes/_DV/Body/Prototypes/rodentia.yml
+++ b/Resources/Prototypes/_DV/Body/Prototypes/rodentia.yml
@@ -24,11 +24,9 @@
     torso:
       part: TorsoRodentia
       organs:
-        #heart: OrganMouseHeart
-        heart: OrganHumanHeart
+        heart: OrganMouseHeart
         lungs: OrganHumanLungs
-        #stomach: OrganRodentiaStomach
-        stomach: OrganHumanStomach
+        stomach: OrganRodentiaStomach
         liver: OrganAnimalLiver
         kidneys: OrganHumanKidneys
       connections:


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Ports The Den's rotting rework, causing meat to decay into gastrotoxin over time instead of all at once. Rotting corpses now impart their level of rot onto meat butchered from them, and corpses can now rot on meat spikes if unrefrigerated. Rodentia can now metabolize raw meat, gastrotoxin, and mold. 

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Ported gradual rotting
- [x] Fixed corpses not rotting on meatspikes
- [x] Ported detritivore metabolizer type and added it to Rodentia 

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added gradual food rotting system
- add: Rodentia can eat rotten food
- fix: Meatspikes no longer preserve corpses at room temperature 
