### PR TITLE
small fixes, vox are real again

### DIFF
--- a/Resources/Locale/en-US/station-events/events/random-sentience.ftl
+++ b/Resources/Locale/en-US/station-events/events/random-sentience.ftl
@@ -1,20 +1,20 @@
 ﻿## Phrases used for where central command got this information.
-random-sentience-event-data-1 = scans from our long-range sensors
-random-sentience-event-data-2 = our sophisticated probabilistic models
-random-sentience-event-data-3 = our omnipotence
-random-sentience-event-data-4 = the communications traffic on your station
-random-sentience-event-data-5 = energy emissions we detected
-random-sentience-event-data-6 = [REDACTED]
+random-sentience-event-data-0 = scans from our long-range sensors
+random-sentience-event-data-1 = our sophisticated probabilistic models
+random-sentience-event-data-2 = our omnipotence
+random-sentience-event-data-3 = the communications traffic on your station
+random-sentience-event-data-4 = energy emissions we detected
+random-sentience-event-data-5 = [REDACTED]
 
 ## Phrases used to describe the level of intelligence, though it doesn't actually affect anything.
-random-sentience-event-strength-1 = human
-random-sentience-event-strength-2 = primate
-random-sentience-event-strength-3 = moderate
-random-sentience-event-strength-4 = security
-random-sentience-event-strength-5 = command
-random-sentience-event-strength-6 = clown
-random-sentience-event-strength-7 = low
-random-sentience-event-strength-8 = AI
+random-sentience-event-strength-0 = human
+random-sentience-event-strength-1 = primate
+random-sentience-event-strength-2 = moderate
+random-sentience-event-strength-3 = security
+random-sentience-event-strength-4 = command
+random-sentience-event-strength-5 = clown
+random-sentience-event-strength-6 = low
+random-sentience-event-strength-7 = AI
 
 ## Announcement text
 

--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -12,7 +12,7 @@
   table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
     children:
     - id: GameRuleMeteorSwarmSmall
-      prob: 0.15
+      prob: 0.01
 
 - type: entityTable
   id: MeteorSwarmMildTable
@@ -32,8 +32,8 @@
     - id: GameRuleMeteorSwarmSmall
     - id: GameRuleMeteorSwarmMedium
     - id: GameRuleMeteorSwarmLarge
-    - id: GameRuleUristSwarm
-    - id: ImmovableRodSpawn
+    #- id: GameRuleUristSwarm - this is so dumb lmao
+    #- id: ImmovableRodSpawn
 
 - type: weightedRandomEntity
   id: MeteorSpawnAsteroidWallTable
@@ -106,7 +106,7 @@
   - type: StationEvent
     weight: 44
     earliestStart: 2
-    minimumPlayers: 0
+    minimumPlayers: 8
   - type: MeteorSwarm
     announcement: null
     announcementSound: null
@@ -126,7 +126,7 @@
   components:
   - type: StationEvent
     weight: 22
-    minimumPlayers: 0
+    minimumPlayers: 10
   - type: MeteorSwarm
     announcement: station-event-space-dust-announcement
     announcementSound: /Audio/Announcements/attention.ogg
@@ -158,6 +158,7 @@
   components:
   - type: StationEvent
     weight: 10
+    minimumPlayers: 20
   - type: MeteorSwarm
     meteors:
       MeteorSmall: 3
@@ -170,6 +171,7 @@
   components:
   - type: StationEvent
     weight: 5
+    minimumPlayers: 30
   - type: MeteorSwarm
     meteors:
       MeteorSmall: 2

--- a/Resources/Prototypes/Species/vox.yml
+++ b/Resources/Prototypes/Species/vox.yml
@@ -1,7 +1,7 @@
 - type: species
   id: Vox
   name: species-name-vox
-  roundStart: false # sad...
+  roundStart: true # fucking what is the upstream doing lmao
   prototype: MobVox
   sprites: MobVoxSprites
   markingLimits: MobVoxMarkingLimits

--- a/Resources/Prototypes/_Lavaland/Procedural/lavaland_planets.yml
+++ b/Resources/Prototypes/_Lavaland/Procedural/lavaland_planets.yml
@@ -15,8 +15,8 @@
   - 25.10312 # nitrogen
   - 8.21301 # carbon dioxide
   weather:
-  - AshfallLight
-  - AshfallHeavy
+  #- AshfallLight
+  #- AshfallHeavy
   markers:
   - RandomTendrilLavaland
   - ChasmLavaland

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -131,7 +131,7 @@
   description: extended-description
   rules:
   - BasicStationEventScheduler
-  - MeteorSwarmScheduler
+  #- MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
   #- LavalandStormScheduler # Lavaland Change
 
@@ -167,7 +167,7 @@
   showInVote: false #Admin Use
   description: secret-description
   rules:
-  - MeteorSwarmScheduler
+  #- MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
   #- LavalandStormScheduler # Lavaland Change
@@ -310,7 +310,7 @@
   - Changeling
   - SubGamemodesRule
   - BasicStationEventScheduler
-  - MeteorSwarmScheduler
+  #- MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
   #- LavalandStormScheduler # Lavaland Change

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -9,6 +9,6 @@
     Zombie: 0.03
     Zombieteors: 0.01
     Shadowling: 0.12
-    KesslerSyndrome: 0.001
+    KesslerSyndrome: 0.1
     Revolutionary: 0.03
     Extended: 0.01 # DO NOT REMOVE THIS AGAIN YOU CLOWNS. IT CRASHES IT ALL OF THE ABOVE ARE INVALID.


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

- fix bad ftls
- enable vox roundstart (why were they gone???)
- fix meteorswarms (?)
- change secret weights a bit
- remove meteor swarms from any lowpop gamemode

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] enable vox
- [x] fix random-sentienceevent-0
- [x] make meteors better?
- [x] remove lrp meteor events from event tables

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: vox are roundstart species again
- tweak: meteor event player requirements
- fix: bad ftls
- remove: Urist mcMeteor, immovable rods, random zombieteors (???)
