### PR TITLE
remove powercheck cause everyone hates it.

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -17,7 +17,7 @@
     - id: MassHallucinations
     - id: MimicVendorRule
     - id: MouseMigration
-    - id: PowerGridCheck
+    #- id: PowerGridCheck
     - id: RandomSentience
     - id: SlimesSpawn
     - id: SolarFlare
@@ -270,16 +270,16 @@
     duration: 240
   - type: KudzuGrowthRule
 
-- type: entity
+- type: entity # make this have better prereqs later on?
   id: PowerGridCheck
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
-    weight: 5
+    weight: 3 # changed weighting
     startAnnouncement: true
     endAnnouncement: true
-    duration: 60
-    maxDuration: 120
+    duration: 15 #
+    maxDuration: 60 #
   - type: PowerGridCheckRule
 
 - type: entity
@@ -287,11 +287,11 @@
   id: SolarFlare
   components:
   - type: StationEvent
-    weight: 8
+    weight: 3
     startAnnouncement: true
     endAnnouncement: true
-    duration: 120
-    maxDuration: 240
+    duration: 15 #its kind of hell on lowpop to not have greencomms
+    maxDuration: 120
   - type: SolarFlareRule
     onlyJamHeadsets: true
     affectedChannels:
@@ -327,7 +327,7 @@
   - type: StationEvent
     startAnnouncement: true
     earliestStart: 20
-    minimumPlayers: 15
+    minimumPlayers: 5 # i think slimes are simple enough for lowpop
     weight: 3
     duration: 60
   - type: VentCrittersRule

--- a/Resources/Prototypes/_Lavaland/Procedural/lavaland_weather.yml
+++ b/Resources/Prototypes/_Lavaland/Procedural/lavaland_weather.yml
@@ -3,11 +3,11 @@
   weatherType: AshfallLight
   damage:
     types:
-      Heat: 4
+      Heat: 0.5 #im gonna nerf this until we figure out a way to fix the fuckass storm
 
 - type: lavalandWeather
   id: AshfallHeavy
   weatherType: Ashfall
   damage:
     types:
-      Heat: 6
+      Heat: 1

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -11,7 +11,7 @@
   - SpaceTrafficControlEventScheduler
   - SpaceTrafficControlFriendlyEventScheduler
   - BasicRoundstartVariation
-  #- LavalandStormScheduler # Lavaland Change
+  - LavalandStormScheduler # Lavaland Change
 
 - type: gamePreset
   id: KesslerSyndrome
@@ -27,7 +27,7 @@
   - RampingStationEventScheduler
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
-  #- LavalandStormScheduler # Lavaland Change
+  - LavalandStormScheduler # Lavaland Change
 
 - type: gamePreset
   id: SurvivalHellshift
@@ -42,7 +42,7 @@
   - SpaceTrafficControlEventScheduler
   - SpaceTrafficControlFriendlyEventScheduler
   - BasicRoundstartVariation
-  #- LavalandStormScheduler # Lavaland Change
+  - LavalandStormScheduler # Lavaland Change
 
 - type: gamePreset
   id: SurvivalIrregular
@@ -56,7 +56,7 @@
   - SpaceTrafficControlEventScheduler
   - SpaceTrafficControlFriendlyEventScheduler
   - BasicRoundstartVariation
-  #- LavalandStormScheduler # Lavaland Change
+  - LavalandStormScheduler # Lavaland Change
 
 - type: gamePreset
   id: SurvivalIrregularExtended
@@ -70,7 +70,7 @@
   - SpaceTrafficControlEventScheduler
   - SpaceTrafficControlFriendlyEventScheduler
   - BasicRoundstartVariation
-  #- LavalandStormScheduler # Lavaland Change
+  - LavalandStormScheduler # Lavaland Change
 
 - type: gamePreset
   id: AllAtOnce
@@ -91,7 +91,7 @@
   - RampingStationEventScheduler
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
-  #- LavalandStormScheduler # Lavaland Change
+  - LavalandStormScheduler # Lavaland Change
 
 - type: gamePreset
   id: AllerAtOnce
@@ -119,7 +119,7 @@
   - SpaceTrafficControlEventScheduler
   - SpaceTrafficControlFriendlyEventScheduler
   - BasicRoundstartVariation
-  #- LavalandStormScheduler # Lavaland Change
+  - LavalandStormScheduler # Lavaland Change
 
 - type: gamePreset
   id: Extended
@@ -133,7 +133,7 @@
   - BasicStationEventScheduler
   - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
-  #- LavalandStormScheduler # Lavaland Change
+  - LavalandStormScheduler # Lavaland Change
 
 - type: gamePreset
   id: Greenshift
@@ -145,7 +145,7 @@
   description: greenshift-description
   rules:
   - SpaceTrafficControlFriendlyEventScheduler
-  #- LavalandStormScheduler # Lavaland Change
+  - LavalandStormScheduler # Lavaland Change
 
 - type: gamePreset
   id: Secret
@@ -157,7 +157,7 @@
   description: secret-description
   rules:
   - Secret
-  #- LavalandStormScheduler # Lavaland Change
+  - LavalandStormScheduler # Lavaland Change
 
 - type: gamePreset
   id: SecretExtended #For Admin Use: Runs Extended but shows "Secret" in lobby.
@@ -170,7 +170,7 @@
   - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
-  #- LavalandStormScheduler # Lavaland Change
+  - LavalandStormScheduler # Lavaland Change
 
 - type: gamePreset
   id: SecretGreenshift #For Admin Use: Runs Greenshift but shows "Secret" in lobby.
@@ -182,7 +182,7 @@
   rules:
   - SpaceTrafficControlFriendlyEventScheduler
   - BasicRoundstartVariation
-  #- LavalandStormScheduler # Lavaland Change
+  - LavalandStormScheduler # Lavaland Change
 
 - type: gamePreset
   id: Sandbox
@@ -194,7 +194,7 @@
   maxPlayers: 5
   rules:
   - Sandbox
-  #- LavalandStormScheduler # Lavaland Change
+  - LavalandStormScheduler # Lavaland Change
 
 - type: gamePreset
   id: Traitor
@@ -211,7 +211,7 @@
   #- MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
-  #- LavalandStormScheduler # Lavaland Change
+  - LavalandStormScheduler # Lavaland Change
 
 - type: gamePreset
   id: Deathmatch
@@ -240,7 +240,7 @@
   #- MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
-  #- LavalandStormScheduler # Lavaland Change
+  - LavalandStormScheduler # Lavaland Change
 
 - type: gamePreset
   id: Revolutionary
@@ -258,7 +258,7 @@
   #- MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
-  #- LavalandStormScheduler # Lavaland Change
+  - LavalandStormScheduler # Lavaland Change
 
 - type: gamePreset
   id: Zombie
@@ -277,7 +277,7 @@
   #- MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
-  #- LavalandStormScheduler # Lavaland Change
+  - LavalandStormScheduler # Lavaland Change
 
 - type: gamePreset
   id: Zombieteors
@@ -294,7 +294,7 @@
   - KesslerSyndromeScheduler
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
-  #- LavalandStormScheduler # Lavaland Change
+  - LavalandStormScheduler # Lavaland Change
 
 - type: gamePreset
   id: Changeling
@@ -313,4 +313,4 @@
   - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
-  #- LavalandStormScheduler # Lavaland Change
+  - LavalandStormScheduler # Lavaland Change


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->
- get rid of the stupid power check event i hate
- solar flare doesn't last as long now, happens less
- small chance for slimes to spawn randomly so lowpop sec has something to do aside from drink.
- remove the fog probably. the storm is back until then so lets all die
- tweak lavaland ashfall damage to not make it suck as much as it does right now
---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->
 
- [x] the fog is gone probably
- [x] remove power check
- [x] make solar flare less insufferable
- [x] more lowpop events
- [x] hit my head against the wall that is lavaland some more   

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- remove: powergrid check from event rotation
- tweak: solar flare weighting and duration
- tweak: population requirements on slime event
- tweak: lavaland ashfall damage
- tweak: re-enable lavaland storm until i know why the fog happens (pain)
