### PR TITLE
stamina resist on armor, some small tweaks!

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Clothing/OuterClothing/armor.yml
@@ -16,6 +16,8 @@
         Slash: 0.80
         Piercing: 0.50
         Heat: 0.80
+  - type: StaminaDamageResistance
+    coefficient: 0.75
   - type: ClothingSpeedModifier
     walkModifier: 0.90
     sprintModifier: 0.90
@@ -41,6 +43,8 @@
         Slash: 0.60
         Piercing: 0.90
         Heat: 0.90
+  - type: StaminaDamageResistance
+    coefficient: 0.75
   - type: ExplosionResistance # Better than nothing against a blast or shockwave.
     damageCoefficient: 0.90
   - type: AllowSuitStorage
@@ -62,6 +66,8 @@
         Slash: 0.40
         Piercing: 0.70
         Heat: 0.70
+  - type: StaminaDamageResistance
+    coefficient: 0.5
   - type: ClothingSpeedModifier
     walkModifier: 0.75
     sprintModifier: 0.75

--- a/Resources/Prototypes/DeltaV/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Clothing/OuterClothing/coats.yml
@@ -16,6 +16,8 @@
         Slash: 0.8
         Piercing: 0.8
         Heat: 0.8
+  - type: StaminaDamageResistance # gds
+    coefficient: 0.75
 
 - type: entity
   parent: ClothingOuterStorageBase
@@ -34,6 +36,8 @@
         Slash: 0.8
         Piercing: 0.8
         Heat: 0.8
+  - type: StaminaDamageResistance # gds
+    coefficient: 0.75
   - type: AllowSuitStorage
 
 - type: entity
@@ -54,6 +58,8 @@
       coefficients:
         Slash: 0.9
         Heat: 0.75
+  - type: StaminaDamageResistance # gds
+    coefficient: 0.95
 
 - type: entity
   parent: ClothingOuterStorageBase
@@ -75,6 +81,8 @@
         Slash: 0.85
         Piercing: 0.85
         Heat: 0.75
+  - type: StaminaDamageResistance # gds
+    coefficient: 0.75
   - type: AllowSuitStorage
 
 - type: entity
@@ -95,6 +103,8 @@
       coefficients:
         Slash: 0.9
         Heat: 0.75
+  - type: StaminaDamageResistance # gds
+    coefficient: 0.95
 
 - type: entity
   parent: ClothingOuterStorageBase
@@ -116,6 +126,8 @@
         Slash: 0.95
         Piercing: 0.95
         Heat: 0.75
+  - type: StaminaDamageResistance # go go gadget self-antag // gds
+    coefficient: 0.8
   - type: AllowSuitStorage #Syndicate Windbreaker, so gun.
 
 - type: entity
@@ -159,6 +171,8 @@
   - type: TemperatureProtection
     heatingCoefficient: 0.1
     coolingCoefficient: 0.1
+  - type: StaminaDamageResistance # gds
+    coefficient: 0.85
 
 - type: entity
   parent: ClothingOuterStorageBase

--- a/Resources/Prototypes/DeltaV/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -23,6 +23,8 @@
         Radiation: 0.75
         Caustic: 0.75
         Heat: 0.75
+  - type: StaminaDamageResistance # gds
+    coefficient: 0.75
   - type: ClothingSpeedModifier
     walkModifier: 0.75
     sprintModifier: 0.75
@@ -68,6 +70,8 @@
         Radiation: 0.80
         Caustic: 0.80
         Heat: 0.80
+  - type: StaminaDamageResistance # gds
+    coefficient: 0.75
   - type: ClothingSpeedModifier
     walkModifier: 0.85
     sprintModifier: 0.85
@@ -113,6 +117,8 @@
         Radiation: 0.70
         Caustic: 0.70
         Heat: 0.40
+  - type: StaminaDamageResistance # gds
+    coefficient: 0.75
   - type: ClothingSpeedModifier
     walkModifier: 0.60
     sprintModifier: 0.60
@@ -158,6 +164,8 @@
         Radiation: 0.75
         Caustic: 0.75
         Heat: 0.75
+  - type: StaminaDamageResistance # gds
+    coefficient: 0.75
   - type: ClothingSpeedModifier
     walkModifier: 0.80
     sprintModifier: 0.80

--- a/Resources/Prototypes/DeltaV/Entities/Clothing/OuterClothing/vests.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Clothing/OuterClothing/vests.yml
@@ -15,6 +15,8 @@
         Slash: 0.9
         Piercing: 0.75
         Heat: 0.9
+  - type: StaminaDamageResistance # gds // oldworld flak jacket so its whatever
+    coefficient: 0.85
   - type: ExplosionResistance
     damageCoefficient: 0.9
 
@@ -35,6 +37,8 @@
         Slash: 0.9
         Piercing: 0.75
         Heat: 0.9
+  - type: StaminaDamageResistance # gds
+    coefficient: 0.75
   - type: ExplosionResistance
     damageCoefficient: 0.9
 

--- a/Resources/Prototypes/DeltaV/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -15,6 +15,8 @@
         Slash: 0.7
         Piercing: 0.4 #Stronger than the warden's armored jacket, because shenanigans and CC spends alot of money.
         Heat: 0.75
+  - type: StaminaDamageResistance
+    coefficient: 0.6 # built CCO tough
   - type: AllowSuitStorage
 
 - type: entity
@@ -27,7 +29,7 @@
     sprite: DeltaV/Clothing/OuterClothing/WinterCoats/corpo_jacket.rsi
   - type: Clothing
     sprite: DeltaV/Clothing/OuterClothing/WinterCoats/corpo_jacket.rsi
-    
+
 - type: entity
   parent: ClothingOuterWinterCoat
   id: ClothingOuterDenimJacket
@@ -56,4 +58,6 @@
         Slash: 0.85
         Piercing: 0.85
         Heat: 0.75
+  - type: StaminaDamageResistance
+    coefficient: 0.75
   - type: AllowSuitStorage

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -18,6 +18,8 @@
         Slash: 0.70
         Piercing: 0.70 #Can save you, but bullets will still hurt. Will take about 10 shots from a Viper before critting, as opposed to 7 while unarmored and 16~ with a bulletproof vest.
         Heat: 0.80
+  - type: StaminaDamageResistance
+    coefficient: 0.8
   - type: ExplosionResistance
     damageCoefficient: 0.90
   - type: Fixtures
@@ -63,6 +65,8 @@
         Piercing: 0.7
         Heat: 0.9
         Caustic: 0.9
+  - type: StaminaDamageResistance
+    coefficient: 0.65
   - type: ExplosionResistance
     damageCoefficient: 0.9
   - type: GroupExamine
@@ -89,6 +93,8 @@
         Heat: 0.85
         Radiation: 0.75
         Caustic: 0.85
+  - type: StaminaDamageResistance
+    coefficient: 0.65
   - type: ExplosionResistance
     damageCoefficient: 0.50
   - type: ClothingSpeedModifier # Burdensome for running, but perfect for speedy gliding, even though running is still probably better
@@ -115,6 +121,8 @@
         Slash: 0.95
         Piercing: 0.5
         Heat: 0.95
+  - type: StaminaDamageResistance
+    coefficient: 0.75 #still armor even if its bunk against other stuff, its nonconductive too so stunbatons probably wouldnt do much on the ceramic plates
 
 - type: entity
   parent: ClothingOuterArmorBasic
@@ -135,6 +143,8 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.7
+  - type: StaminaDamageResistance
+    coefficient: 0.75
   - type: Reflect
     reflectProb: 0.33
     innate: true # armor grants a passive shield that does not require concentration to maintain
@@ -164,6 +174,8 @@
         Piercing: 0.35
         Heat: 0.35
         Caustic: 0.5
+  - type: StaminaDamageResistance
+    coefficient: 0.55 # RIDE THE LIGHTNING
   - type: ExplosionResistance
     damageCoefficient: 0.35
   - type: ClothingSpeedModifier
@@ -230,6 +242,8 @@
         Slash: 0.5
         Piercing: 0.6
         Heat: 0.5
+  - type: StaminaDamageResistance
+    coefficient: 0.75
   - type: GroupExamine
 
 - type: entity
@@ -251,6 +265,8 @@
         Heat: 0.5
         Radiation: 0
         Caustic: 0.75
+  - type: StaminaDamageResistance
+    coefficient: 0.55 # big armor heavy. uhm . thing
   - type: GroupExamine
   - type: ProtectedFromStepTriggers
     slots: WITHOUT_POCKET
@@ -276,6 +292,8 @@
         Piercing: 0.65
         Heat: 0.65
         Caustic: 0.75
+  - type: StaminaDamageResistance
+    coefficient: 0.6 # is good ya
   - type: GroupExamine
   - type: ProtectedFromStepTriggers
     slots: WITHOUT_POCKET
@@ -352,6 +370,9 @@
   - type: ExplosionResistance
     damageCoefficient: 0.65
   - type: GroupExamine
+  - type: StaminaDamageResistance
+    coefficient: 0.6 #not as good as the tengri but still decent for walking around. fuck stun meta
+
 
 - type: entity
   parent: [ ClothingOuterBaseLarge, BaseMajorContraband, AllowSuitStorageClothing ]
@@ -371,6 +392,8 @@
         Piercing: 0.5
         Heat: 0.9
         Radiation: 0.8
+  - type: StaminaDamageResistance
+    coefficient: 0.75 # hardsuit basically
   - type: ClothingSpeedModifier
     walkModifier: 0.7
     sprintModifier: 0.65
@@ -400,6 +423,8 @@
         Blunt: 0.6
         Slash: 0.8
         Piercing: 0.4
+  - type: StaminaDamageResistance
+    coefficient: 0.65 # bone is nonconductive to shock. stun batons would not do as much probably
   - type: ClothingSpeedModifier
     walkModifier: 0.8
   - type: HeldSpeedModifier
@@ -429,6 +454,8 @@
         Slash: 0.5
         Piercing: 0.6
         Heat: 0.5
+  - type: StaminaDamageResistance
+    coefficient: 0.5 # i would love to get shot out of a pod from low orbit
   - type: GroupExamine
   - type: ProtectedFromStepTriggers
     slots: WITHOUT_POCKET
@@ -451,6 +478,8 @@
         Piercing: 0.6
         Heat: 0.5
         Caustic: 0.9
+  - type: StaminaDamageResistance
+    coefficient: 0.6
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
@@ -61,6 +61,8 @@
     sprite: Clothing/OuterClothing/Bio/security.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Bio/security.rsi
+  - type: StaminaDamageResistance
+    coefficient: 0.75
 
 - type: entity
   parent: ClothingOuterBioGeneral

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -33,6 +33,8 @@
         Slash: 0.70
         Piercing: 0.70
         Heat: 0.80
+  - type: StaminaDamageResistance
+    coefficient: 0.85 # its got some durathread probably
   - type: ExplosionResistance
     damageCoefficient: 1 #its a coat. it doesnt do shit
 
@@ -94,6 +96,8 @@
         Piercing: 0.7
         Heat: 0.7
         Caustic: 0.75 # not the full 90% from ss13 because of the head
+  - type: StaminaDamageResistance
+    coefficient: 0.6 # just the same as the other hos/cap values
   - type: ExplosionResistance
     damageCoefficient: 0.9
 
@@ -109,6 +113,8 @@
         Slash: 0.7
         Piercing: 0.7
         Heat: 0.7
+  - type: StaminaDamageResistance
+    coefficient: 0.65
   - type: ExplosionResistance
     damageCoefficient: 0.9
 
@@ -155,6 +161,8 @@
     modifiers:
       coefficients:
         Slash: 0.95
+  - type: StaminaDamageResistance
+    coefficient: 0.95
   - type: Food
     requiresSpecialDigestion: true
   - type: SolutionContainerManager
@@ -388,6 +396,8 @@
         Blunt: 0.8
         Slash: 0.65
         Piercing: 0.85
+  - type: StaminaDamageResistance
+    coefficient: 0.85
 
 - type: entity
   parent: ClothingOuterStorageBase
@@ -440,6 +450,8 @@
         Piercing: 0.85
         Heat: 0.75
         Caustic: 0.75
+  - type: StaminaDamageResistance
+    coefficient: 0.85
 
 - type: entity
   parent: ClothingOuterStorageBase
@@ -481,6 +493,8 @@
     sprite: Clothing/OuterClothing/Coats/space_asshole.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Coats/space_asshole.rsi
+  - type: StaminaDamageResistance
+    coefficient: 0.65 #shitter bait lole
 
 - type: entity
   parent: ClothingOuterStorageBase
@@ -492,6 +506,9 @@
     sprite: Clothing/OuterClothing/Coats/expensive_coat.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Coats/expensive_coat.rsi
+  - type: TemperatureProtection # GDS - WHY WAS THIS NOT HERE BEFOREEEE
+    heatingCoefficient: 1.1
+    coolingCoefficient: 0.1
 
 - type: entity
   parent: ClothingOuterBase
@@ -579,6 +596,9 @@
     sprite: Clothing/OuterClothing/Coats/submariner.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Coats/submariner.rsi
+  - type: TemperatureProtection # OCEAN IS COOOLD RAAAGHHH GET IT TOGETHER GUYS!!!!!
+    heatingCoefficient: 1.1
+    coolingCoefficient: 0.1
 
 - type: entity
   parent: [ClothingOuterFoldableBaseOpened, ClothingOuterCoatSubmariner]

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -27,6 +27,8 @@
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitBasic
+  - type: StaminaDamageResistance
+    coefficient: 0.65
 
 #Atmospherics Hardsuit
 - type: entity
@@ -70,6 +72,8 @@
     clothingPrototype: ClothingHeadHelmetHardsuitAtmos
   - type: GuideHelp
     guides: [ HephaestusIndustries ]
+  - type: StaminaDamageResistance
+    coefficient: 0.65
 
 #Engineering Hardsuit
 - type: entity
@@ -89,6 +93,8 @@
         shader: unshaded
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitEngineeringUnpainted
+  - type: StaminaDamageResistance
+    coefficient: 0.75 # 25%
 
 - type: entity
   parent: [ClothingOuterHardsuitBase, BaseIntegratedMagboot]
@@ -157,6 +163,8 @@
         Piercing: 0.9
         Radiation: 0.3 #salv is supposed to have radiation hazards in the future
         Caustic: 0.8
+  - type: StaminaDamageResistance
+    coefficient: 0.75 #
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.8
@@ -195,6 +203,8 @@
         Piercing: 0.5
         Radiation: 0.3
         Caustic: 0.7
+  - type: StaminaDamageResistance
+    coefficient: 0.75 #
   - type: ClothingSpeedModifier
     walkModifier: 0.75
     sprintModifier: 0.75
@@ -229,6 +239,8 @@
         Heat: 0.7 #Goliath hide gets grilled instead of you
         Radiation: 0.3
         Caustic: 0.8
+  - type: StaminaDamageResistance
+    coefficient: 0.65 #its fancy so its better idk
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
@@ -264,6 +276,8 @@
         Piercing: 0.5
         Heat: 0.3
         Radiation: 0.1
+  - type: StaminaDamageResistance
+    coefficient: 0.65 #its fancy so its better. bite my hip.
   - type: ExplosionResistance
     damageCoefficient: 0.2
   - type: TemperatureProtection
@@ -304,6 +318,8 @@
         Caustic: 0.5
   - type: StealTarget
     stealGroup: ClothingOuterHardsuitVoidParamed
+  - type: StaminaDamageResistance
+    coefficient: 0.75 # parameds need protection too idk. the modsuit will do more and have better armor in exchange for more slowdown
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9
@@ -542,6 +558,8 @@
     modifiers:
       coefficients:
         Caustic: 0.1
+  - type: StaminaDamageResistance
+    coefficient: 0.75 #
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.95
@@ -665,6 +683,8 @@
     clothingPrototype: ClothingHeadHelmetHardsuitLuxury
   - type: GuideHelp
     guides: [ HephaestusIndustries ]
+  - type: StaminaDamageResistance
+    coefficient: 0.7
 
 #ANTAG HARDSUITS
 #Blood-red Hardsuit
@@ -944,6 +964,9 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
+  - type: ClothingGrantComponent #wizards uhm uhm uhm they uhm they make the crystal or something in their tower idk
+    component:
+    - type: SupermatterImmune
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitWizard
@@ -973,6 +996,8 @@
         Slash: 0.95
         Piercing: 1
         Heat: 0.5
+  - type: StaminaDamageResistance
+    coefficient: 0.65 #
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
@@ -1003,6 +1028,8 @@
         Piercing: 0.9
         Heat: 0.4
         Caustic: 0.75
+  - type: StaminaDamageResistance
+    coefficient: 0.75 # 25%
   - type: ClothingSpeedModifier
     walkModifier: 0.6
     sprintModifier: 0.6
@@ -1045,7 +1072,7 @@
   - type: StaticPrice
     price: 0
   - type: StaminaDamageResistance
-    coefficient: 0.75 # 25%
+    coefficient: 0.6 # higher than the shitter pirate
 
 #CENTCOMM / ERT HARDSUITS
 #ERT Leader Hardsuit
@@ -1222,6 +1249,8 @@
         Shock: 0.1
         Radiation: 0.1
         Caustic: 0.1
+  - type: StaminaDamageResistance
+    coefficient: 0.5 # 50%
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
@@ -1230,7 +1259,7 @@
     clothingPrototype: ClothingHeadHelmetCBURN
 
 #MISC. HARDSUITS
-#Clown Hardsuit
+#Clown Hardsuit // dont ever give this stun resist
 - type: entity
   parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitClown
@@ -1263,7 +1292,7 @@
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitClown
 
-#Mime Hardsuit
+#Mime Hardsuit // or this one
 - type: entity
   parent: ClothingOuterHardsuitClown
   id: ClothingOuterHardsuitMime
@@ -1303,6 +1332,8 @@
         Slash: 0.9
         Piercing: 0.85
         Caustic: 0.8
+  - type: StaminaDamageResistance
+    coefficient: 0.5 # 50% // HOHOHO!!!
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
@@ -9,6 +9,8 @@
     sprite: Clothing/OuterClothing/Suits/eva.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Suits/eva.rsi
+  - type: StaminaDamageResistance
+    coefficient: 0.85
   - type: Tag
     tags:
     - SuitEVA
@@ -28,6 +30,8 @@
     sprite: Clothing/OuterClothing/Suits/eva_syndicate.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Suits/eva_syndicate.rsi
+  - type: StaminaDamageResistance
+    coefficient: 0.85
   - type: Tag
     tags:
     - SuitEVA
@@ -47,6 +51,8 @@
     sprite: Clothing/OuterClothing/Suits/eva_emergency.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Suits/eva_emergency.rsi
+  - type: StaminaDamageResistance
+    coefficient: 0.95
   - type: ClothingSpeedModifier
     walkModifier: 0.7
     sprintModifier: 0.7
@@ -61,7 +67,7 @@
     containers:
       toggleable-clothing: !type:Container {}
 
-#Prisoner EVA
+#Prisoner EVA - no stun resist on this please
 - type: entity
   parent: ClothingOuterEVASuitBase
   id:  ClothingOuterHardsuitEVAPrisoner
@@ -91,6 +97,8 @@
     sprite: Clothing/OuterClothing/Suits/ancient_voidsuit.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Suits/ancient_voidsuit.rsi
+  - type: StaminaDamageResistance
+    coefficient: 0.75
   - type: ClothingSpeedModifier
     walkModifier: 0.85
     sprintModifier: 0.85

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -18,6 +18,8 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.75
+  - type: StaminaDamageResistance
+    coefficient: 0.65 #shitter bait lole
   - type: ExplosionResistance
     damageCoefficient: 0.15
   - type: GroupExamine
@@ -76,6 +78,8 @@
         Slash: 0.9
         Heat: 0.8
         Cold: 0.8
+  - type: StaminaDamageResistance
+    coefficient: 0.75
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.7
@@ -112,6 +116,8 @@
         Slash: 0.9
         Heat: 0.8
         Cold: 0.8
+  - type: StaminaDamageResistance
+    coefficient: 0.75
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
@@ -138,6 +144,8 @@
       coefficients:
         Heat: 0.90
         Radiation: 0.001
+  - type: StaminaDamageResistance
+    coefficient: 0.85
   - type: Clothing
     sprite: Clothing/OuterClothing/Suits/rad.rsi
   - type: GroupExamine
@@ -179,6 +187,8 @@
         Slash: 0.8
         Piercing: 0.8
         Heat: 0.8
+  - type: StaminaDamageResistance
+    coefficient: 0.75
   # phase cloak
   - type: ToggleClothing
     action: ActionTogglePhaseCloak
@@ -316,6 +326,8 @@
     coolingCoefficient: 0.01
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCarp
+  - type: StaminaDamageResistance
+    coefficient: 0.75
 
 - type: entity # From Upstream
   parent: ClothingOuterBase

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
@@ -16,6 +16,8 @@
         Slash: 0.6
         Piercing: 0.3
         Heat: 0.9
+  - type: StaminaDamageResistance
+    coefficient: 0.85
   - type: ExplosionResistance
     damageCoefficient: 0.9
 
@@ -37,6 +39,8 @@
         Slash: 0.7
         Piercing: 0.5
         Heat: 0.9
+  - type: StaminaDamageResistance
+    coefficient: 0.85
   - type: ExplosionResistance
     damageCoefficient: 0.9
 
@@ -58,6 +62,8 @@
         Slash: 0.70
         Piercing: 0.70 #Can save you, but bullets will still hurt. Will take about 10 shots from a Viper before critting, as opposed to 7 while unarmored and 16~ with a bulletproof vest.
         Heat: 0.80
+  - type: StaminaDamageResistance
+    coefficient: 0.85
   - type: ExplosionResistance
     damageCoefficient: 0.90
 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -125,6 +125,8 @@
         Slash: 0.75
         Piercing: 0.75
         Heat: 0.75
+  - type: StaminaDamageResistance
+    coefficient: 0.65
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -244,6 +246,8 @@
         Heat: 0.90
         Caustic: 0.75
     priceMultiplier: 0.15
+  - type: StaminaDamageResistance
+    coefficient: 0.8
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodWinterChem
 
@@ -274,6 +278,8 @@
         Heat: 0.90
         Caustic: 0.75
     priceMultiplier: 0.15
+  - type: StaminaDamageResistance
+    coefficient: 0.8
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodWinterCMO
 
@@ -337,6 +343,8 @@
         Heat: 0.90
         Caustic: 0.9
     priceMultiplier: 0.15
+  - type: StaminaDamageResistance
+    coefficient: 0.8
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodWinterSci
 
@@ -409,6 +417,8 @@
         Piercing: 0.75
         Heat: 0.75
         Caustic: 0.75 #not the full 90% from ss13 because of the head
+  - type: StaminaDamageResistance
+    coefficient: 0.65
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -460,6 +470,8 @@
         Heat: 0.9
         Caustic: 0.9
     priceMultiplier: 0.15
+  - type: StaminaDamageResistance
+    coefficient: 0.95
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodWinterJani
 
@@ -490,6 +502,8 @@
         Heat: 0.90
         Caustic: 0.9
     priceMultiplier: 0.15
+  - type: StaminaDamageResistance
+    coefficient: 0.95
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodWinterMed
 
@@ -566,6 +580,8 @@
         Heat: 0.75
         Caustic: 0.9
     priceMultiplier: 0.15
+  - type: StaminaDamageResistance
+    coefficient: 0.85
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodWinterPara
 
@@ -620,6 +636,8 @@
         Heat: 0.90
         Caustic: 0.9
     priceMultiplier: 0.15
+  - type: StaminaDamageResistance
+    coefficient: 0.85
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodWinterRD
 
@@ -674,6 +692,8 @@
         Heat: 0.90
         Caustic: 0.9
     priceMultiplier: 0.15
+  - type: StaminaDamageResistance
+    coefficient: 0.95
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodWinterSci
 
@@ -706,6 +726,8 @@
         Slash: 0.85
         Piercing: 0.85 #Can save you, but bullets will still hurt. Will take about 10 shots from a Viper before critting, as opposed to 7 while unarmored and 16~ with a bulletproof vest.
         Heat: 0.75
+  - type: StaminaDamageResistance
+    coefficient: 0.85
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -734,6 +756,8 @@
         Heat: 0.90
         Caustic: 0.9
     priceMultiplier: 0.15
+  - type: StaminaDamageResistance
+    coefficient: 0.85
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodWinterSci
 
@@ -775,6 +799,8 @@
       - state: WARD-equipped-OUTERCLOTHING
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodWinterWarden
+  - type: StaminaDamageResistance
+    coefficient: 0.95
 
 - type: entity
   parent: [ClothingOuterWinterCoatToggleable, BaseSyndicateContraband]

--- a/Resources/Prototypes/Entities/Objects/Devices/translators.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/translators.yml
@@ -38,7 +38,7 @@
   components:
   - type: ItemToggle
   - type: PowerCellDraw
-    drawRate: 1
+    drawRate: 0.3
   - type: ItemSlots
     slots:
       cell_slot:

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1457,6 +1457,15 @@
     - ClothingUniformJumpsuitWardenGrey # DeltaV - alternate sec uniforms
     - ClothingUniformJumpskirtWardenGrey # DeltaV - alternate sec uniforms
     - ClothingHeadHatParamedicsoft
+    - ClothingUniformJumpsuitHD
+    - ClothingUniformJumpsuitHDTurtle
+    - ClothingUniformJumpsuitHospitalityDirectorBartender
+    - ClothingUniformJumpsuitHospitalityDirectorBotany
+    - ClothingUniformJumpsuitHospitalityDirectorJanitor
+    - ClothingUniformJumpskirtHD
+    - ClothingUniformJumpskirtHDTurtle
+    - ClothingUniformJumpskirtHospitalityDirectorBartender
+    - ClothingUniformJumpskirtHospitalityDirectorJanitor
     # Winter outfits
     - ClothingOuterWinterCap
     - ClothingOuterWinterCE
@@ -1487,9 +1496,11 @@
     - ClothingOuterWinterSci
     - ClothingOuterWinterRobo
     - ClothingOuterWinterSec
+    - ClothingOuterWinterHD
     # Ties
     - ClothingNeckTieRed
     - ClothingNeckTieDet
+    - ClothingNeckMantleHD
     - ClothingNeckTieSci
     # Scarfs - All scarfs avaible in winterdrobe
     - ClothingNeckScarfStripedGreen
@@ -1500,6 +1511,8 @@
     - ClothingNeckScarfStripedOrange
     - ClothingNeckScarfStripedBlack
     - ClothingNeckScarfStripedPurple
+    # Hats
+    - ClothingHeadHatBellhopHD
     # Carpets
     - Carpet
     - CarpetBlack

--- a/Resources/Prototypes/Nyanotrasen/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Clothing/OuterClothing/armor.yml
@@ -14,12 +14,14 @@
         Blunt: 0.9
         Slash: 0.9
         Piercing: 0.8
+  - type: StaminaDamageResistance
+    coefficient: 0.85
 
 - type: entity
   parent: ClothingOuterBase
   id: ClothingOuterArmorKendoBogu
   name: bogu
-  description: A set of armor used in Kendo. It covers the waist, torso, and hands. 
+  description: A set of armor used in Kendo. It covers the waist, torso, and hands.
   components:
   - type: Sprite
     sprite: Nyanotrasen/Clothing/OuterClothing/Armor/bogu.rsi
@@ -33,12 +35,14 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.95
     sprintModifier: 0.85
-    
+  - type: StaminaDamageResistance
+    coefficient: 0.75
+
 - type: entity
   parent: ClothingOuterBase
   id: ClothingOuterArmorTouseiGusoku
   name: tousei-gusoku
-  description: A modern replica of a Ni-mai-do Gusoku armor set. 
+  description: A modern replica of a Ni-mai-do Gusoku armor set.
   components:
   - type: Sprite
     sprite: Nyanotrasen/Clothing/OuterClothing/Armor/touseigusoku.rsi
@@ -50,4 +54,5 @@
         Blunt: 0.80
         Slash: 0.60
         Piercing: 0.85
-        
+  - type: StaminaDamageResistance
+    coefficient: 0.75

--- a/Resources/Prototypes/Nyanotrasen/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Clothing/OuterClothing/coats.yml
@@ -15,6 +15,9 @@
         Slash: 0.8
         Piercing: 0.8
         Heat: 0.8
+        Psionic: 0.8 # GDS // GO MY PSIONIC WARRIOR!!!
+  - type: StaminaDamageResistance
+    coefficient: 0.75
   - type: TemperatureProtection
     heatingCoefficient: 0.3
     coolingCoefficient: 0.3

--- a/Resources/Prototypes/Nyanotrasen/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -63,6 +63,16 @@
       sprite: Nyanotrasen/Clothing/OuterClothing/WinterCoats/mantis_winter_coat.rsi
     - type: Clothing
       sprite: Nyanotrasen/Clothing/OuterClothing/WinterCoats/mantis_winter_coat.rsi
+    - type: Armor
+      modifiers:
+        coefficients:
+          Blunt: 0.8
+          Slash: 0.8
+          Piercing: 0.8
+          Heat: 0.8
+          Psionic: 0.8 # GDS // GO MY PSIONIC WARRIOR!!!
+    - type: StaminaDamageResistance
+      coefficient: 0.75
 
 - type: entity
   parent: ClothingOuterWinterRD

--- a/Resources/Prototypes/_EE/Entities/Clothing/BieselRepublic/Modsuits/legionnaire.yml
+++ b/Resources/Prototypes/_EE/Entities/Clothing/BieselRepublic/Modsuits/legionnaire.yml
@@ -100,6 +100,8 @@
       coolingCoefficient: 0.01
     - type: StaminaDamageResistance
       coefficient: 0.5
+    - type: ClothingModifyStunTime # gds
+      modifier: 0.5
     - type: EmitsSoundOnMove
       soundCollection:
         collection: FootstepHardsuitMedium

--- a/Resources/Prototypes/_EE/Entities/Clothing/BieselRepublic/outerwear.yml
+++ b/Resources/Prototypes/_EE/Entities/Clothing/BieselRepublic/outerwear.yml
@@ -36,6 +36,8 @@
           Piercing: 0.5
           Heat: 0.5
           Caustic: 0.5
+    - type: StaminaDamageResistance
+      coefficient: 0.4
     - type: ExplosionResistance
       damageCoefficient: 0.35
     - type: Reflect
@@ -67,6 +69,10 @@
           Slash: 0.80
           Piercing: 0.50
           Heat: 0.80
+    - type: StaminaDamageResistance # GDS
+      coefficient: 0.75
+    - type: ClothingModifyStunTime
+      modifier: 0.5 # LEMME SEE YOUR WAR FACE GRAAARRGH!!!
     - type: ClothingSpeedModifier
       walkModifier: 0.90
       sprintModifier: 0.90
@@ -101,3 +107,5 @@
     - type: TemperatureProtection
       heatingCoefficient: 0.1
       coolingCoefficient: 0.1
+    - type: StaminaDamageResistance # GDS
+      coefficient: 0.75

--- a/Resources/Prototypes/_EE/Entities/Clothing/Generic/outerwear.yml
+++ b/Resources/Prototypes/_EE/Entities/Clothing/Generic/outerwear.yml
@@ -16,6 +16,8 @@
           Piercing: 0.85
           Heat: 0.3
           Caustic: 0.5
+    - type: StaminaDamageResistance
+      coefficient: 0.75
     - type: ExplosionResistance
       damageCoefficient: 0.5
     - type: Reflect
@@ -47,6 +49,8 @@
           Piercing: 0.3
           Heat: 0.85
           Caustic: 0.85
+    - type: StaminaDamageResistance
+      coefficient: 0.5 # heavy armor good
     - type: ExplosionResistance
       damageCoefficient: 0.5
     - type: Reflect
@@ -78,6 +82,8 @@
           Piercing: 0.85
           Heat: 0.85
           Caustic: 0.85
+    - type: StaminaDamageResistance
+      coefficient: 0.55 # more heavier gooder
     - type: ExplosionResistance
       damageCoefficient: 0.5
     - type: Reflect
@@ -106,6 +112,8 @@
         - state: equipped-OUTERCLOTHING
         - state: equipped-OUTERCLOTHING-unshaded
           shader: unshaded
+    - type: StaminaDamageResistance
+      coefficient: 0.65
     - type: Armor
       modifiers:
         coefficients:

--- a/Resources/Prototypes/_EE/Entities/Clothing/SolAlliance/SAN/outerwear.yml
+++ b/Resources/Prototypes/_EE/Entities/Clothing/SolAlliance/SAN/outerwear.yml
@@ -18,3 +18,5 @@
           Heat: 0.80
     - type: ExplosionResistance
       damageCoefficient: 0.90
+    - type: StaminaDamageResistance
+      coefficient: 0.75

--- a/Resources/Prototypes/_EE/Entities/Clothing/Zavodskoi/outerwear.yml
+++ b/Resources/Prototypes/_EE/Entities/Clothing/Zavodskoi/outerwear.yml
@@ -16,6 +16,8 @@
           Slash: 0.95
           Piercing: 0.95
           Heat: 0.85
+    - type: StaminaDamageResistance
+      coefficient: 0.75 # gds
     - type: TemperatureProtection
       heatingCoefficient: 0.1
       coolingCoefficient: 0.1
@@ -38,6 +40,8 @@
           Slash: 0.95
           Piercing: 0.95
           Heat: 0.85
+    - type: StaminaDamageResistance
+      coefficient: 0.75 # gds
     - type: TemperatureProtection
       heatingCoefficient: 0.1
       coolingCoefficient: 0.1
@@ -60,6 +64,8 @@
           Slash: 0.95
           Piercing: 0.95
           Heat: 0.85
+    - type: StaminaDamageResistance
+      coefficient: 0.75 # gds
     - type: TemperatureProtection
       heatingCoefficient: 0.1
       coolingCoefficient: 0.1

--- a/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/praetorian.yml
+++ b/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/praetorian.yml
@@ -21,6 +21,8 @@
           whitelist:
             components:
               - PowerCell
+    - type: PowerCellDraw # gds tweak suitdraw
+      drawRate: 0.3
     - type: Storage
       maxItemSize: Huge
       grid:
@@ -130,6 +132,8 @@
         - NonEnergy
     - type: StaminaDamageResistance
       coefficient: 0.5 # 50%
+    - type: ClothingModifyStunTime # bso should be badass im sorry idk abt balance
+      modifier: 0.5
     - type: PressureProtection
       highPressureMultiplier: 0.45
       lowPressureMultiplier: 1000

--- a/Resources/Prototypes/_Gardenstation/Contractors/employer.yml
+++ b/Resources/Prototypes/_Gardenstation/Contractors/employer.yml
@@ -68,3 +68,8 @@
   - !type:CharacterNationalityRequirement
     nationalities:
     - GoldenDeep
+  - !type:CharacterLifepathRequirement
+    lifepaths:
+    - GdGrandMerchant
+    - GdMerchant
+    - GdThesian

--- a/Resources/Prototypes/_Gardenstation/Entities/Clothing/Back/modsuit.yml
+++ b/Resources/Prototypes/_Gardenstation/Entities/Clothing/Back/modsuit.yml
@@ -16,6 +16,16 @@
       gloves: ClothingModsuitHandsSquire
       outerClothing: ClothingModsuitChestSquire
       shoes: ClothingModsuitSquireBoots
+  - type: ItemSlots
+    slots:
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default
+        startingItem: PowerCellHigh
+        whitelist:
+          components:
+            - PowerCell
+  - type: PowerCellDraw
+    drawRate: 0.3
   - type: SealableClothingVisuals
     visualLayers:
       back:
@@ -43,6 +53,16 @@
       gloves: ClothingModsuitHandsHOS
       outerClothing: ClothingModsuitChestHOS
       shoes: ClothingModsuitHOSboots
+  - type: ItemSlots
+    slots:
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default
+        startingItem: PowerCellHigh
+        whitelist:
+          components:
+          - PowerCell
+  - type: PowerCellDraw
+    drawRate: 0.3
   - type: SealableClothingVisuals
     visualLayers:
       back:

--- a/Resources/Prototypes/_Gardenstation/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/_Gardenstation/Entities/Clothing/Head/hats.yml
@@ -25,7 +25,7 @@
   parent: [ ClothingHeadBase, TranslatorPoweredBase ]
   id: ClothingHeadHatBSODuelistHat
   name: blueshield's parade hat
-  description: A large feathered hat made specially for use by officers in tradeband circles. This one comes with a language skillsoft.
+  description: A large feathered hat made specially for use by officers in tradeband circles. This one comes with a language skillsoft... The brim seems to bladed?
   components:
   - type: Sprite
     sprite: _Gardenstation/Clothing/Head/Hats/bso_duelist_hat.rsi
@@ -35,6 +35,21 @@
     modifier: 0.8
   - type: ClothingModifyStunTime
     modifier: 0.8
+  - type: MeleeWeapon
+    wideAnimationRotation: -135
+    attackRate: .5
+    damage:
+      types:
+        Slash: 5
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
+  - type: LandAtCursor
+  - type: DamageOtherOnHit
+    ignoreResistances: true
+    damage:
+      types:
+        Slash: 10
+        Piercing: 15
   - type: HandheldTranslator
     spoken:
     - TauCetiBasic

--- a/Resources/Prototypes/_Gardenstation/Entities/Clothing/MagicalSuits/Magibunny/cco_magibunny.yml
+++ b/Resources/Prototypes/_Gardenstation/Entities/Clothing/MagicalSuits/Magibunny/cco_magibunny.yml
@@ -98,6 +98,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 1.2
     sprintModifier: 1.2
+  - type: StaminaDamageResistance
+    coefficient: 0.5
+  - type: ClothingModifyStunTime # teehee
+    modifier: 0.3
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/_Gardenstation/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/_Gardenstation/Entities/Clothing/Masks/masks.yml
@@ -24,6 +24,9 @@
     - Hair
   - type: StaminaDamageResistance
     coefficient: 0.95 # 5% stamdgm resist?
+  - type: TemperatureProtection # just to make sure they can go in space and stuff
+    heatingCoefficient: 0.1
+    coolingCoefficient: 0.1
 - type: entity
   parent: ClothingMaskBase
   id: ClothingMaskLoGimp

--- a/Resources/Prototypes/_Gardenstation/Entities/Clothing/ModularArmor/NonFaction/MarkIVModularTacSuit.yml
+++ b/Resources/Prototypes/_Gardenstation/Entities/Clothing/ModularArmor/NonFaction/MarkIVModularTacSuit.yml
@@ -89,6 +89,8 @@
         Slash: 0.7
         Piercing: 0.6 # more bulletproof
         Heat: 0.7
+  - type: StaminaDamageResistance
+    coefficient: 0.8
   - type: ExplosionResistance
     damageCoefficient: 0.9
 

--- a/Resources/Prototypes/_Gardenstation/Entities/Clothing/ModularArmor/TCAF/tcafInfantryModulite.yml
+++ b/Resources/Prototypes/_Gardenstation/Entities/Clothing/ModularArmor/TCAF/tcafInfantryModulite.yml
@@ -85,6 +85,8 @@
         Slash: 0.7
         Piercing: 0.6 # made for bullets - solarians use antiquated weapons because theyre weird conservatives and think lead is a cultural export or some shit
         Heat: 0.8 # i lied because actually i think solarian shitlasers would be really funny. they shoot green beams or something idk
+  - type: StaminaDamageResistance
+    coefficient: 0.8
   - type: ExplosionResistance
     damageCoefficient: 0.9
 

--- a/Resources/Prototypes/_Gardenstation/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_Gardenstation/Entities/Clothing/OuterClothing/armor.yml
@@ -21,6 +21,8 @@
         Holy: 0.97 # someone forgot to charge their crystal lole - see you in the badplace BUDDY
   - type: ExplosionResistance
     damageCoefficient: 0.80
+  - type: StaminaDamageResistance
+    coefficient: 0.7 # carapace is europan plasteel plus like weird psychic bullshit lol
 
 - type: entity
   parent: [ClothingOuterArmorBasic, BaseRestrictedContraband]
@@ -37,7 +39,9 @@
       coefficients:
         Blunt: 0.75
         Slash: 0.8
-        Piercing: 0.65 # more bulletproof than normal kevlar/flak vests - shell armor
+        Piercing: 0.65 # its just straight up made of metal idk man
         Heat: 0.8
   - type: ExplosionResistance
     damageCoefficient: 0.80
+  - type: StaminaDamageResistance
+    coefficient: 0.7

--- a/Resources/Prototypes/_Gardenstation/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/_Gardenstation/Entities/Clothing/OuterClothing/coats.yml
@@ -23,6 +23,8 @@
   - type: TemperatureProtection
     heatingCoefficient: 0.1
     coolingCoefficient: 0.1
+  - type: StaminaDamageResistance
+    coefficient: 0.7
 
 - type: entity
   parent: [ClothingOuterCoatCapTrench]
@@ -52,6 +54,8 @@
   - type: TemperatureProtection
     heatingCoefficient: 0.1
     coolingCoefficient: 0.1
+  - type: StaminaDamageResistance
+    coefficient: 0.7
 
 - type: entity
   parent: [ClothingOuterBaseMedium, AllowSuitStorageClothing, ClothingOuterStorageBase]
@@ -139,6 +143,8 @@
   - type: TemperatureProtection
     heatingCoefficient: 0.1
     coolingCoefficient: 0.1
+  - type: StaminaDamageResistance
+    coefficient: 0.8
 
 - type: entity
   parent: [ClothingOuterBaseMedium, AllowSuitStorageClothing, ClothingOuterStorageBase]
@@ -169,6 +175,8 @@
   - type: TemperatureProtection
     heatingCoefficient: 0.1
     coolingCoefficient: 0.1
+  - type: StaminaDamageResistance
+    coefficient: 0.8
 
 - type: entity
   parent: [ ClothingOuterCoatCapTrench, ClothingOuterStorageFoldableBase, ClothingNeckBase ]
@@ -186,11 +194,11 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.6
+        Blunt: 0.5
         Slash: 0.5
-        Piercing: 0.5 # lined with durathread, kevlar inlay. Generals should try to not get assassinated probably?
+        Piercing: 0.6
         Heat: 0.5
-        Caustic: 0.6
+        Caustic: 0.9
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
@@ -220,14 +228,14 @@
     sprite: _Gardenstation/Clothing/OuterClothing/Coats/cco_trech.rsi
   - type: Clothing
     sprite: _Gardenstation/Clothing/OuterClothing/Coats/cco_trech.rsi
-  - type: Armor # not as robust cause cco ghostrole might have it at some point idfk
+  - type: Armor # its just captain coat armorval
     modifiers:
       coefficients:
-        Blunt: 0.4
-        Slash: 0.4
-        Piercing: 0.4
-        Heat: 0.45
-        Caustic: 0.6
+        Blunt: 0.5
+        Slash: 0.5
+        Piercing: 0.6
+        Heat: 0.5
+        Caustic: 0.9
         Psionic: 0.7 # they know
   - type: ClothingSpeedModifier
     walkModifier: 1.0

--- a/Resources/Prototypes/_Gardenstation/Entities/Clothing/OuterClothing/modsuit.yml
+++ b/Resources/Prototypes/_Gardenstation/Entities/Clothing/OuterClothing/modsuit.yml
@@ -49,6 +49,8 @@
     - type: TemperatureProtection
       heatingCoefficient: 0.1
       coolingCoefficient: 0.1
+  - type: StaminaDamageResistance
+    coefficient: 0.45
 
 # sec suit
 
@@ -85,11 +87,11 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.8
-        Heat: 0.8
-        Radiation: 0.6
+        Blunt: 0.75
+        Slash: 0.75
+        Piercing: 0.6
+        Caustic: 0.7
+        Heat: 0.7
   - type: ComponentToggler
     components:
     - type: PressureProtection
@@ -102,6 +104,8 @@
     damageCoefficient: 0.65
   - type: FireProtection
     reduction: 0.5
+  - type: StaminaDamageResistance
+    coefficient: 0.75
 
 - type: entity
   parent: ClothingModsuitChestplateStandard
@@ -140,7 +144,7 @@
         Slash: 0.5
         Piercing: 0.5
         Radiation: 0.6
-        Caustic: 0.6
+        Caustic: 0.5
         Heat: 0.6
   - type: ComponentToggler
     components:
@@ -152,3 +156,5 @@
       coolingCoefficient: 0.1
   - type: FireProtection
     reduction: 0.5
+  - type: StaminaDamageResistance
+    coefficient: 0.5

--- a/Resources/Prototypes/_Gardenstation/Entities/Clothing/OuterClothing/vests.yml
+++ b/Resources/Prototypes/_Gardenstation/Entities/Clothing/OuterClothing/vests.yml
@@ -30,8 +30,7 @@
     sprite: _Gardenstation/Clothing/OuterClothing/Vests/cargo_vest.rsi
   - type: Clothing
     sprite: _Gardenstation/Clothing/OuterClothing/Vests/cargo_vest.rsi
-    equipDelay: 15
-    unequipDelay: 1200
+  - type: Unremoveable
   - type: Armor #Based on /tg/ but slightly compensated to fit the fact that armor stacks in SS14.
     modifiers:
       coefficients:
@@ -40,3 +39,6 @@
         Piercing: 0.90
   - type: StaminaDamageResistance
     coefficient: 0.90 # 5% stamdgm resist?
+  - type: TemperatureProtection # just so they can go in space or something idk. theyll still die very quickly
+    heatingCoefficient: 0.1
+    coolingCoefficient: 0.1

--- a/Resources/Prototypes/_Gardenstation/Entities/Objects/pda.yml
+++ b/Resources/Prototypes/_Gardenstation/Entities/Objects/pda.yml
@@ -19,6 +19,13 @@
     state: pda-justicar
   - type: PdaBorderColor
     borderColor: "#333333"
+  - type: UnpoweredFlashlight
+  - type: PointLight
+    enabled: false
+    radius: 1.5
+    softness: 5
+    autoRot: true
+    color: Red
   - type: CartridgeLoader
     preinstalled:
     - CrewManifestCartridge

--- a/Resources/Prototypes/_Gardenstation/Entities/Structures/Wallmount/walldecor.yml
+++ b/Resources/Prototypes/_Gardenstation/Entities/Structures/Wallmount/walldecor.yml
@@ -9,6 +9,9 @@
   - type: Sprite
     sprite: _Gardenstation/Structures/Wallmounts/wallmounts.rsi
     state: bieselflag
+  - type: Construction
+    graph: BieselBanner
+    node: bieselbannerfull
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Wood
@@ -30,6 +33,9 @@
   - type: Sprite
     sprite: _Gardenstation/Structures/Wallmounts/wallmounts.rsi
     state: solflag
+  - type: Construction
+    graph: SolBanner
+    node: solbannerfull
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Wood
@@ -51,6 +57,9 @@
   - type: Sprite
     sprite: _Gardenstation/Structures/Wallmounts/wallmounts.rsi
     state: elyraflag
+  - type: Construction
+    graph: ElyraBanner
+    node: elyrabannerfull
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Wood
@@ -72,6 +81,9 @@
   - type: Sprite
     sprite: _Gardenstation/Structures/Wallmounts/wallmounts.rsi
     state: praflag
+  - type: Construction
+    graph: PRABanner
+    node: prabannerfull
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Wood
@@ -93,6 +105,9 @@
   - type: Sprite
     sprite: _Gardenstation/Structures/Wallmounts/wallmounts.rsi
     state: goldendeepflag
+  - type: Construction
+    graph: GoldenDeepBanner
+    node: goldendeepbannerfull
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Wood

--- a/Resources/Prototypes/_Gardenstation/Recipes/Construction/Graphs/flag.yml
+++ b/Resources/Prototypes/_Gardenstation/Recipes/Construction/Graphs/flag.yml
@@ -1,0 +1,135 @@
+﻿#biesel
+- type: constructionGraph
+  id: BieselBanner
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: bieselbannerfull
+      steps:
+      - material: Cloth
+        amount: 4
+        doAfter: 2
+  - node: bieselbannerfull
+    entity: Ar13WallFlagBiesel
+    edges:
+    - to: start
+      completed:
+      - !type:SpawnPrototype
+        prototype: MaterialCloth1
+        amount: 3 #returns 1 less as one breaks
+      - !type:DeleteEntity {}
+      conditions:
+      - !type:EntityAnchored
+        anchored: true
+      steps:
+      - tool: Cutting
+        doAfter: 2
+#sol
+- type: constructionGraph
+  id: SolBanner
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: solbannerfull
+      steps:
+      - material: Cloth
+        amount: 4
+        doAfter: 3
+  - node: solbannerfull
+    entity: Ar13WallFlagSol
+    edges:
+    - to: start
+      completed:
+      - !type:SpawnPrototype
+        prototype: MaterialCloth1
+        amount: 3 #returns 1 less as one breaks
+      - !type:DeleteEntity {}
+      conditions:
+      - !type:EntityAnchored
+        anchored: true
+      steps:
+      - tool: Cutting
+        doAfter: 2
+#pra
+- type: constructionGraph
+  id: PRABanner
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: prabannerfull
+      steps:
+      - material: Cloth
+        amount: 4
+        doAfter: 3
+  - node: prabannerfull
+    entity: Ar13WallFlagPRA
+    edges:
+    - to: start
+      completed:
+      - !type:SpawnPrototype
+        prototype: MaterialCloth1
+        amount: 3 #returns 1 less as one breaks
+      - !type:DeleteEntity {}
+      conditions:
+      - !type:EntityAnchored
+        anchored: true
+      steps:
+      - tool: Cutting
+        doAfter: 2
+#elyra
+- type: constructionGraph
+  id: ElyraBanner
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: elyrabannerfull
+      steps:
+      - material: Cloth
+        amount: 4
+        doAfter: 3
+  - node: elyrabannerfull
+    entity: Ar13WallFlagElyra
+    edges:
+    - to: start
+      completed:
+      - !type:SpawnPrototype
+        prototype: MaterialCloth1
+        amount: 3 #returns 1 less as one breaks
+      - !type:DeleteEntity {}
+      conditions:
+      - !type:EntityAnchored
+        anchored: true
+      steps:
+      - tool: Cutting
+        doAfter: 2
+#goldendeep
+- type: constructionGraph
+  id: GoldenDeepBanner
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: goldendeepbannerfull
+      steps:
+      - material: Cloth
+        amount: 4
+        doAfter: 3
+  - node: goldendeepbannerfull
+    entity: Ar13WallFlagGoldenDeep
+    edges:
+    - to: start
+      completed:
+      - !type:SpawnPrototype
+        prototype: MaterialCloth1
+        amount: 3 #returns 1 less as one breaks
+      - !type:DeleteEntity {}
+      conditions:
+      - !type:EntityAnchored
+        anchored: true
+      steps:
+      - tool: Cutting
+        doAfter: 2

--- a/Resources/Prototypes/_Gardenstation/Recipes/Construction/decoration.yml
+++ b/Resources/Prototypes/_Gardenstation/Recipes/Construction/decoration.yml
@@ -1,0 +1,88 @@
+﻿#flags
+
+#biesel
+- type: construction
+  name: Republic of Biesel flag
+  id: BieselWallBanner
+  graph: BieselBanner
+  startNode: start
+  targetNode: bieselbannerfull
+  category: construction-category-furniture
+  description: Sweet liberty- its BEAUTIFUL!!
+  icon:
+    sprite: _Gardenstation/Structures/Wallmounts/wallmounts.rsi
+    state: bieselflag
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: true
+  conditions:
+  - !type:WallmountCondition
+
+#sol
+- type: construction
+  name: Sol Alliance flag
+  id: SolWallBanner
+  graph: SolBanner
+  startNode: start
+  targetNode: solbannerfull
+  category: construction-category-furniture
+  description: The icon of the Sol Alliance! Quite rare to see this far into the spur nowadays...
+  icon:
+    sprite: _Gardenstation/Structures/Wallmounts/wallmounts.rsi
+    state: solflag
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: true
+  conditions:
+  - !type:WallmountCondition
+#pra
+- type: construction
+  name: The People's Republic of Adhomai flag
+  id: PRAWallBanner
+  graph: PRABanner
+  startNode: start
+  targetNode: prabannerfull
+  category: construction-category-furniture
+  description: On adhomai you can find one of these in every PRA citizen's home.
+  icon:
+    sprite: _Gardenstation/Structures/Wallmounts/wallmounts.rsi
+    state: praflag
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: true
+  conditions:
+  - !type:WallmountCondition
+#elyra
+- type: construction
+  name: banner of The Serene Republic of Elyra
+  id: ElyraWallBanner
+  graph: ElyraBanner
+  startNode: start
+  targetNode: elyrabannerfull
+  category: construction-category-furniture
+  description: A banner with the the Elyran falcon on it. A shockingly rare sight outside of its home planet...
+  icon:
+    sprite: _Gardenstation/Structures/Wallmounts/wallmounts.rsi
+    state: elyraflag
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: true
+  conditions:
+  - !type:WallmountCondition
+#goldendeep
+- type: construction
+  name: Golden Deep flag
+  id: GoldenDeepWallBanner
+  graph: GoldenDeepBanner
+  startNode: start
+  targetNode: goldendeepbannerfull
+  category: construction-category-furniture
+  description: The tradeseal of the Midas Collective, emblazoned on a flag.
+  icon:
+    sprite: _Gardenstation/Structures/Wallmounts/wallmounts.rsi
+    state: goldendeepflag
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: true
+  conditions:
+  - !type:WallmountCondition

--- a/Resources/Prototypes/_Gardenstation/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/_Gardenstation/Recipes/Lathes/clothing.yml
@@ -1,0 +1,33 @@
+﻿# mantle
+
+- type: latheRecipe
+  id: ClothingNeckMantleBsoParadeMantle
+  result: ClothingNeckMantleBsoParadeMantle
+  completetime: 3
+  materials:
+    Cloth: 250
+    Durathread: 350 # its got a lotta durathread idk
+
+- type: latheRecipe
+  id: ClothingNeckMantleBieselFlag # HAVE A CUPPAH LIBER-TEAAA!!!!!!
+  result: ClothingNeckMantleBieselFlag
+  completetime: 3
+  materials:
+    Cloth: 250
+
+# suits
+
+- type: latheRecipe
+  id: ClothingUniformJumpsuitBSOParadeUniform
+  result: ClothingUniformJumpsuitBSOParadeUniform
+  completetime: 4.3
+  materials:
+    Cloth: 420 # ruffles have ridges
+
+- type: latheRecipe
+  id: ClothingUniformJumpsuitConsularBlackSuit
+  result: ClothingUniformJumpsuitConsularBlackSuit
+  completetime: 4
+  materials:
+    Cloth: 300 # only the un-associated diplomat suit should be allowed to be printed, otherwise everyone will be impersonating government officials lmao
+

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/armour.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/armour.yml
@@ -16,6 +16,8 @@
         Slash: 0.60
         Piercing: 0.65
         Heat: 0.70
+  - type: StaminaDamageResistance
+    coefficient: 0.75
   - type: ExplosionResistance
     damageCoefficient: 0.8
 
@@ -64,6 +66,8 @@
         Slash: 0.60
         Piercing: 0.65
         Heat: 0.70
+  - type: StaminaDamageResistance
+    coefficient: 0.75
   - type: TemperatureProtection
     heatingCoefficient: 0.1
     coolingCoefficient: 0.1

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/modsuit.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/modsuit.yml
@@ -37,6 +37,8 @@
         Piercing: 0.85
         Heat: 0.85
         Radiation: 0.6
+  - type: StaminaDamageResistance
+    coefficient: 0.85 # standard plate is doody
   - type: ComponentToggler
     components:
     - type: PressureProtection

--- a/Resources/Prototypes/_Impstation/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Lathes/clothing.yml
@@ -1,0 +1,94 @@
+﻿#hats
+
+- type: latheRecipe
+  id: ClothingHeadHatBellhopHD
+  result: ClothingHeadHatBellhopHD
+  completetime: 3.2
+  materials:
+    Cloth: 200
+
+# mantle
+
+- type: latheRecipe
+  id: ClothingNeckMantleHD
+  result: ClothingNeckMantleHD
+  completetime: 3
+  materials:
+    Cloth: 250
+
+# wintercoat
+
+- type: latheRecipe
+  id: ClothingOuterWinterHD
+  result: ClothingOuterWinterHD
+  completetime: 3.2
+  materials:
+    Cloth: 500
+    Durathread: 200
+
+# skirts
+
+- type: latheRecipe
+  id: ClothingUniformJumpskirtHD
+  result: ClothingUniformJumpskirtHD
+  completetime: 4
+  materials:
+    Cloth: 300
+
+- type: latheRecipe
+  id: ClothingUniformJumpskirtHDTurtle
+  result: ClothingUniformJumpskirtHDTurtle
+  completetime: 4
+  materials:
+    Cloth: 300
+
+- type: latheRecipe
+  id: ClothingUniformJumpskirtHospitalityDirectorBartender
+  result: ClothingUniformJumpskirtHospitalityDirectorBartender
+  completetime: 4
+  materials:
+    Cloth: 300
+
+- type: latheRecipe
+  id: ClothingUniformJumpskirtHospitalityDirectorJanitor
+  result: ClothingUniformJumpskirtHospitalityDirectorJanitor
+  completetime: 4
+  materials:
+    Cloth: 300
+
+# suits
+
+- type: latheRecipe
+  id: ClothingUniformJumpsuitHD
+  result: ClothingUniformJumpsuitHD
+  completetime: 4
+  materials:
+    Cloth: 300
+
+- type: latheRecipe
+  id: ClothingUniformJumpsuitHDTurtle
+  result: ClothingUniformJumpsuitHDTurtle
+  completetime: 4
+  materials:
+    Cloth: 300
+
+- type: latheRecipe
+  id: ClothingUniformJumpsuitHospitalityDirectorBartender
+  result: ClothingUniformJumpsuitHospitalityDirectorBartender
+  completetime: 4
+  materials:
+    Cloth: 300
+
+- type: latheRecipe
+  id: ClothingUniformJumpsuitHospitalityDirectorBotany
+  result: ClothingUniformJumpsuitHospitalityDirectorBotany
+  completetime: 4
+  materials:
+    Cloth: 300
+
+- type: latheRecipe
+  id: ClothingUniformJumpsuitHospitalityDirectorJanitor
+  result: ClothingUniformJumpsuitHospitalityDirectorJanitor
+  completetime: 4
+  materials:
+    Cloth: 300

--- a/Resources/Prototypes/_Lavaland/Entities/Clothing/explorer_suit.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Clothing/explorer_suit.yml
@@ -16,8 +16,10 @@
         Blunt: 0.70
         Slash: 0.70
         Piercing: 0.70
-        Heat: 0.75 # parity with 13 :) 
+        Heat: 0.75 # parity with 13 :)
         Caustic: 0.50
+  - type: StaminaDamageResistance # gds
+    coefficient: 0.75
   - type: ExplosionResistance
     damageCoefficient: 0.50
   - type: ContainerContainer
@@ -26,6 +28,9 @@
   - type: ToggleableClothing
     clothingPrototypes:
       head: LavalandEquipmentExplorerHood
+  - type: PressureProtection #
+    highPressureMultiplier: 0.9
+    lowPressureMultiplier: 750
   - type: Construction
     graph: ExplorerSuit
     node: start
@@ -56,8 +61,11 @@
         Blunt: 0.90
         Slash: 0.90
         Piercing: 0.90
-        Heat: 0.70 # parity with 13 :) 
+        Heat: 0.70 # parity with 13 :)
         Caustic: 0.90
+  - type: PressureProtection # idk man
+    highPressureMultiplier: 0.9
+    lowPressureMultiplier: 350
 
 - type: entity
   parent: LavalandEquipmentExplorerSuit
@@ -74,6 +82,8 @@
         Piercing: 0.70
         Heat: 0.75
         Caustic: 0.50
+  - type: StaminaDamageResistance # gds
+    coefficient: 0.6
   - type: Sprite
     sprite: _Lavaland/Equipment/explorer_suit.rsi
     state: reinforced1-icon
@@ -130,6 +140,8 @@
         Piercing: 0.70
         Heat: 0.75
         Caustic: 0.50
+  - type: StaminaDamageResistance # gds
+    coefficient: 0.65
   - type: ToggleableClothing
     clothingPrototypes:
       head: LavalandEquipmentExplorerHoodReinforced2
@@ -180,6 +192,11 @@
         Piercing: 0.70
         Heat: 0.75
         Caustic: 0.50
+  - type: StaminaDamageResistance #gds
+    coefficient: 0.5
+  - type: PressureProtection # full upgrade exp suit should be spacefaring idk
+    highPressureMultiplier: 0.09
+    lowPressureMultiplier: 1000
   - type: ToggleableClothing
     clothingPrototypes:
       head: LavalandEquipmentExplorerHoodReinforced3
@@ -208,3 +225,6 @@
         Piercing: 0.90
         Heat: 0.70
         Caustic: 0.90
+  - type: PressureProtection #see base
+    highPressureMultiplier: 0.1
+    lowPressureMultiplier: 1000

--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/armor_punk.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/armor_punk.yml
@@ -17,6 +17,8 @@
         Piercing: 0.75 #Can save you, but bullets will still hurt. Will take about 10 shots from a Viper before critting, as opposed to 7 while unarmored and 16~ with a bulletproof vest.
         Heat: 0.80
         Caustic: 0.9
+  - type: StaminaDamageResistance
+    coefficient: 0.75
   - type: ExplosionResistance
     damageCoefficient: 0.90
 

--- a/Resources/Prototypes/_Shitmed/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Clothing/OuterClothing/armor.yml
@@ -81,5 +81,7 @@
         Piercing: 0.85
         Radiation: 0.85
         Caustic: 0.25
+  - type: StaminaDamageResistance # gds
+    coefficient: 0.75
   - type: ExplosionResistance
     damageCoefficient: 0.85

--- a/Resources/Prototypes/_TG/Entities/Clothing/Modsuits/SyndicateModsuits.yml
+++ b/Resources/Prototypes/_TG/Entities/Clothing/Modsuits/SyndicateModsuits.yml
@@ -101,6 +101,8 @@
     - type: TemperatureProtection
       heatingCoefficient: 0.01
       coolingCoefficient: 0.01
+    - type: StaminaDamageResistance # gds
+      coefficient: 0.5
     - type: ClothingModifyStunTime
       modifier: 0.5
     - type: Reflect
@@ -245,6 +247,8 @@
     - type: TemperatureProtection
       heatingCoefficient: 0.01
       coolingCoefficient: 0.01
+    - type: StaminaDamageResistance # gds
+      coefficient: 0.55
     - type: ClothingModifyStunTime
       modifier: 0.5
     - type: Reflect


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

A variety of small changes and additions that aren't really important enough to warrant their own branches/PR's
BIG CHANGES:
- armor has stun resist
- bso hat can be used as a throwing weapon (thanks fails)
- craftable flags
- small background changes
- modsuit powerdrain fix
- squire and centurion controls have a highcap on roundstart.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [ ] make the bso hat return to hand after its thrown maybe? idk
- [x] stun resistance on armor
- [x] craftable flags
- [x] remove annoying modsuit drain
- [x] modsuits have powercells in them now (you can use seclites again! yay!)   
- [x] buff squire suit (nobody actually plays sec) 

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: stun resistance to most armor
- add: BSO parade hat functions as a throwing weapon
- add: Sec modsuits have roundstart power cells
- add: nation banners are now craftable
- tweak: armor value on certain modsuit parts
- tweak: bso modsuit has a stun recovery tag now
- fix: security modsuits draining power too fast (@ me if you think this needs further tweak?)
